### PR TITLE
[JA DateTimeV2] DateTimeModel support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -127,13 +127,14 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string TimeOfSpecialDayRegex = @"(今晚|今早|今晨|明晚|明早|明晨|昨晚)(的|在)?";
       public const string DateTimePeriodTillRegex = @"(?<till>到|直到|--|-|—|——)";
       public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*的|在\s*$)";
+      public const string BeforeAfterRegex = @"^\b$";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string HourNumRegex = @"(?<hour>[零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)";
       public const string ZhijianRegex = @"^\s*(之间|之内|期间|中间|间)";
       public const string DateTimePeriodThisRegex = @"这个|这一个|这|这一";
       public const string DateTimePeriodLastRegex = @"上个|上一个|上|上一";
       public const string DateTimePeriodNextRegex = @"下个|下一个|下|下一";
-      public const string AmPmDescRegex = @"(?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))";
+      public const string AmPmDescRegex = @"(?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m|上午|中午|下午|午后|晚上|夜里|夜晚|夜间|深夜|傍晚|晚|早间?))";
       public const string TimeOfDayRegex = @"(?<timeOfDay>凌晨|清晨|早上|早间|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晚)";
       public static readonly string SpecificTimeOfDayRegex = $@"((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})\s+{TimeOfDayRegex})|(今晚|今早|今晨|明晚|明早|明晨|昨晚))";
       public const string DateTimePeriodUnitRegex = @"(个)?(?<unit>(小时|钟头|分钟|秒钟|时|分|秒))";
@@ -175,6 +176,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
             @"时"
         };
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|分钟?|秒钟?|个?小时|时|个?钟头|天|个?星期|周|週|个?月|年)";
+      public const string AnUnitRegex = @"^[.]";
       public const string DurationConnectorRegex = @"^\s*(?<connector>[多又余零]?)\s*$";
       public const string ConnectorRegex = @"^\s*,\s*$";
       public static readonly string LunarHolidayRegex = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年))(的)?)?(?<holiday>除夕|春节|中秋节|中秋|元宵节|端午节|端午|重阳节)";
@@ -222,11 +224,14 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string FromToRegex = @"(从|自).+([至到]).+";
       public const string AmbiguousRangeModifierPrefix = @"(从|自)";
       public const string ReferenceDatePeriodRegex = @"^[.]";
+      public const string UnspecificDatePeriodRegex = @"^[.]";
       public const string ParserConfigurationBefore = @"((?<include>和|或|及)?(之前|以前)|前)";
       public const string ParserConfigurationAfter = @"((?<include>和|或|及)?(之后|之後|以后|以後)|后|後)";
       public const string ParserConfigurationUntil = @"(直到|直至|截至|截止(到)?)";
       public const string ParserConfigurationSincePrefix = @"(自从|自|自打|打|从)";
       public const string ParserConfigurationSinceSuffix = @"(以来|开始|起)";
+      public const string ParserConfigurationAroundPrefix = @"^[.]";
+      public const string ParserConfigurationAroundSuffix = @"^[.]";
       public const string ParserConfigurationLastWeekDayRegex = @"最后一个";
       public const string ParserConfigurationNextMonthRegex = @"下一个";
       public const string ParserConfigurationLastMonthRegex = @"上一个";
@@ -295,6 +300,10 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly IList<string> ThisYearTerms = new List<string>
         {
             @"今年"
+        };
+      public static readonly IList<string> YearToDateTerms = new List<string>
+        {
+            @"今年迄今"
         };
       public static readonly IList<string> LastYearTerms = new List<string>
         {
@@ -664,6 +673,18 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string DateTimePeriodAFRegex = @"(下午|午后|傍晚)";
       public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚)";
       public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜)";
+      public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"早", @"(?<!今|明|日|号)早(?!上)" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -677,6 +677,10 @@ namespace Microsoft.Recognizers.Definitions.Chinese
         {
             { @"^[.]", @"^[.]" }
         };
+      public static readonly Dictionary<string, string> AmbiguityTimePeriodFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
       public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
         {
             { @"^[.]", @"^[.]" }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string RegionTitleRegex = @"(昭和|平成|令和|大正|明治|寛政|享和|文化|文政|天保|弘化|嘉永|安政|万延|文久|元治|慶応)";
       public static readonly string DynastyYearRegex = $@"((?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{{1,2}}|({ZeroToNineIntegerRegexCJK}){{1,3}}))年?)|(((?<Keio>慶応)|(?<Meiji>明治)|(?<Taisho>大正)|(?<Showa>昭和)|(?<Heisei>平成)|(?<Reiwa>令和))(\d+|元|{ZeroToNineIntegerRegexCJK})年)";
       public static readonly string DateYearInCJKRegex = $@"(?<yearCJK>({ZeroToNineIntegerRegexCJK}{{2,4}}|{DynastyYearRegex}))年?";
-      public const string WeekDayRegex = @"(週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)";
+      public const string WeekDayRegex = @"(前の?)?(週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)";
       public static readonly string WeekDayStartEnd = $@"(^(の)?{WeekDayRegex}|{WeekDayRegex}$)";
       public const string LunarRegex = @"(农历|初一|正月|大年|旧暦)";
       public static readonly string DateThisRegex = $@"(这个|这一个|这|这一|本|(?<week>今週)|これ?)(的|の)?({WeekDayRegex}|日)";
-      public static readonly string DateLastRegex = $@"(上一个|上个|上一|上|最后一个|最后|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)";
+      public static readonly string DateLastRegex = $@"(上一个|上个|上一|上|最后一个|最后|前の?|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)";
       public static readonly string DateNextRegex = $@"(下一个|下个|下一|下|(?<week>(来|翌)週)|次)(的|の)?{WeekDayRegex}";
       public static readonly string WeekWithWeekDayRangeRegex = $@"({DateThisRegex}|{DateNextRegex}|{DateLastRegex})(から)({WeekDayRegex})";
       public const string WoMLastRegex = @"過去|去|最後|先";
@@ -62,10 +62,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string SpecialDate = $@"(?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})年)?(の|的)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})(の|的)?月)?(の|的)?{DateDayRegexInCJK}";
       public const string DateUnitRegex = @"(?<unit>年|个月|月|周|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)";
       public const string BeforeRegex = @"以前|之前|前|先";
-      public const string AfterRegex = @"過ぎ|以内|以后|以後|之后|之後|后|後|で(?!す)|あと|以降";
-      public const string TimePeriodLeftRegex = @"あと";
+      public const string AfterRegex = @"過ぎ|以后|以後|之后|之後|后|後|で(?!す)|あと|以降";
+      public const string TimePeriodLeftRegex = @"(?<LatePrefix>あとで?)|(?<EarlyPrefix>の早い時間)";
       public static readonly string DateRegexList1 = $@"({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,)*{WeekDayRegex})?)";
-      public static readonly string DateRegexList2 = $@"(({SimpleYearRegex}|{DateYearInCJKRegex}){MonthRegexForPeriod}\s*)";
+      public static readonly string DateRegexList2 = $@"((?<!「)今){WeekDayRegex}\s*[/\\\-]?\s*({MonthRegex}\s*[/\\\-]?\s*{DayRegex}|\({MonthRegex}\s*[/\\\-]?\s*{DayRegex}\))";
       public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?";
       public static readonly string DateRegexList4 = $@"(?<!\d){MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\d*%)((\s+|\s*,\s*)({SimpleYearRegex}|{DateYearInCJKRegex}))?((\s|,)*{WeekDayRegex})?(?!\d)";
       public static readonly string DateRegexList5 = $@"(?<!\d){DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}(?!\d*%)((\s+|\s*,\s*)({SimpleYearRegex}|{DateYearInCJKRegex}))?((\s|,)*{WeekDayRegex})?(?!\d)";
@@ -95,7 +95,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string YearAndMonth = $@"(({YearNumRegex}|{DateYearInCJKRegex})の?\s*{MonthRegex}(\b|から)?)";
       public static readonly string SimpleYearAndMonth = $@"({DateRangePrepositions})({YearNumRegex}[/\\\-]{MonthNumRegex}(\b|から)$)";
       public static readonly string PureNumYearAndMonth = $@"({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})(?!\d)|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})";
-      public static readonly string OneWordPeriodRegex = $@"({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<!休|建国記念)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?";
+      public static readonly string OneWordPeriodRegex = $@"({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<business>営業)日|(?<!休|建国記念|営業)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?";
       public const string LaterEarlyPeriodRegex = @"((?<next>来|翌)|(?<this>今|同じ)|(?<last>この|去|先|前(の)?))?(?<suffix>(?<!建国記念)日(?!付)|(?<week>週(間)?)|(?<month>(正|一|二|三|四|五|六|七|八|九|十|十一|十二|0?[1-9]|1[0-2]))?((?<!((?<![1-9])0))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々|齢)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後|の後半)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>(の)?(半ば|中旬))|(?<EarlyPrefix>(の)?初め|のはじめ|早くに|初旬|(?<RelEarly>ちょっと前に|上旬(に)?)))";
       public const string DatePointWithAgoAndLater = @"((?<today>今日)|(?<yesterday>昨日)|(?<tomorrow>明日))(から|の)(\d)(?<duration>週間|日)((?<within>以内)|(?<more>以上)(?<ago>前)|(?<more>以上(あと)?))";
       public static readonly string WeekOfMonthRegex = $@"({DateRangePrepositions})((?<wom>({YearRegex}\s*)?{MonthSuffixRegex}(的|の))(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)";
@@ -109,14 +109,14 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string YearMonthDayRange = $@"({YearNumRegex}[/\\\-]?({MonthRegex}|{MonthNumRegex})[/\\\-]?({DayRegexForPeriod}|{DateDayRegexInCJK})から{YearNumRegex}[/\\\-]?({MonthRegex}|{MonthNumRegex})[/\\\-]?({DayRegexForPeriod}|{DateDayRegexInCJK})(までの間|まで|の間|にわたって))|(({YearNumRegex})?({MonthRegex}|{MonthNumRegex})[/\\\-]?({DayRegexForPeriod}|{DateDayRegexInCJK}){WeekDayRegex}?から({MonthRegex}|{MonthNumRegex})?({DayRegexForPeriod}|{DateDayRegexInCJK}){WeekDayRegex}(までの間|まで|の間|にわたって))";
       public static readonly string YearMonthRange = $@"({YearNumRegex}[/\\\-]?({MonthRegex}|{MonthNumRegex})から{YearNumRegex}[/\\\-]?({MonthRegex}|{MonthNumRegex})(までの間|まで|の間|にわたって))";
       public static readonly string MonthDayRange = $@"({YearNumRegex})?({MonthRegex}|{MonthNumRegex})[/\\\-]?(({DayRegexForPeriod}|{DateDayRegexInCJK})|{WeekDayRegex})から(({DayRegexForPeriod}|{DateDayRegexInCJK})|{WeekDayRegex})(までの間|まで|の間|にわたって)";
-      public static readonly string YearToYear = $@"({DateRangePrepositions})(({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})から({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})(までの間|まで|の間|にわたって))";
+      public static readonly string YearToYear = $@"({DateRangePrepositions})(({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})から({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})(ま(での間|で)?|の間|にわたって))";
       public const string YearToYearSuffixRequired = @"^[.]";
       public static readonly string MonthToMonth = $@"({DateRangePrepositions})(({SimpleYearRegex}?({SpecialMonthRegex}|{MonthRegex})(SpecialDayRegex}}|{DayRegex})?から({SpecialMonthRegex}|{MonthRegex})(SpecialDayRegex}}|{DayRegex})?(までの間|まで|の間))|({SimpleYearRegex}{MonthRegexForPeriod}から{SimpleYearRegex}{MonthRegexForPeriod}(までの間|まで|の間))|({SimpleYearRegex}[/\\\-](?<monthFrom>{MonthNumRegexForPeriod})から{SimpleYearRegex}[/\\\-](?<monthTo>{MonthNumRegexForPeriod})(までの間|まで|の間)))";
       public const string MonthToMonthSuffixRequired = @"^[.]";
       public static readonly string DayToDay = $@"({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?(({SpecialMonthRegex}|{MonthRegex})の?)?(({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})から(({SpecialMonthRegex}|{MonthRegex})の?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?((今月|来月|{MonthRegex})の?)?({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})(までの間|まで|の間))|{SpecialDayRegex}";
       public static readonly string FirstLastOfYearRegex = $@"(({DatePeriodYearInCJKRegex}|{YearRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))的?)((?<first>前)|(?<last>(最后|最後|最終)))";
       public static readonly string ComplexDatePeriodRegex = $@"({DateRangePrepositions})(?<start>.+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)";
-      public const string PastRegex = @"(?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)";
+      public const string PastRegex = @"(?<before>まで)|(?<past>(この|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)";
       public const string FutureRegex = @"(?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これから(の)?|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))";
       public const string SeasonRegex = @"(?<season>春(?!節)|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?";
       public const string WhichWeekRegex = @"第(?<number>5[0-3]|[1-4]\d|0?[1-9])週";
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string CenturyRegex = $@"({CenturyNumRegex}|{CenturyRegexInCJK})";
       public static readonly string RelativeCenturyRegex = $@"(?<relcentury>({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex}))世紀";
       public const string DecadeRegexInCJK = @"(?<decade>十|一十|二十|三十|四十|五十|六十|七十|八十|九十)";
-      public static readonly string DecadeRegex = $@"({DateRangePrepositions})(?<centurysuf>({CenturyRegex}|{CenturyRegexInCJK}|{RelativeCenturyRegex}))?の?(?<firsttwoyearnum>\d{{2}}(?=\d))?(?<decade>((\d{{1}}0)|{DecadeRegexInCJK}))年代(のごろ)?";
+      public static readonly string DecadeRegex = $@"({DateRangePrepositions})(?<centurysuf>({CenturyRegex}|{CenturyRegexInCJK}|{RelativeCenturyRegex}))?の?(?<century>(?<firsttwoyearnum>\d{{2}}(?=\d)))?(?<decade>((\d{{1}}0)|{DecadeRegexInCJK}))年代(のごろ)?";
       public const string PrepositionRegex = @"(?<prep>^(,?(夜の|的|の(?<timeOfDay>朝|夜|午後|晩)?|t),?|在)$)";
       public const string NowRegex = @"(?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(?!日)(すぐ)?)";
       public const string NightRegex = @"(?<night>早|晚|夜|泊(?=の?予約))";
@@ -140,7 +140,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string SpecialDaySecondRegex = $@"((?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex})秒間?)";
       public const string SpecialDayModRegex = @"((?<after>過ぎに|以降)|(?<in>で)|(?<less>弱|たらず)|(?<more>以上))";
       public static readonly string SpecialDayEndOfRegex = $@"((?<SpecificEndOf>明日の終わり|今?({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))";
-      public static readonly string TimeOfSpecialDayRegex = $@"(({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)";
+      public static readonly string TimeOfSpecialDayRegex = $@"(({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)";
       public const string NowTimeRegex = @"(现在|今)";
       public const string RecentlyTimeRegex = @"(刚刚才?|刚才)";
       public const string AsapTimeRegex = @"(出来る限り早く|立刻|马上)";
@@ -149,7 +149,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string DateTimePeriodFromSuffixRegex = @"(の間|まで(の間)?)";
       public const string DateTimePeriodConnectorRegex = @"(和|与|到)";
       public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*(的|の(?!午)|在)\s*$)";
-      public const string BeforeAfterRegex = @"(前|後)";
+      public const string BeforeAfterRegex = @"(?<!午)(前|後)";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string HourNumRegex = @"(?<hour>[零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)";
       public const string ZhijianRegex = @"^\s*(之间|之内|期间|中间|间)";
@@ -172,10 +172,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string DurationAllRegex = @"(まる)";
       public const string DurationHalfRegex = @"^[.]";
       public const string DurationRelativeDurationUnitRegex = @"(?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|(?<!「)明日)|(?<another>(?<!(に))もう(?=\d)|別)の?(日|週|月)?";
-      public const string AgoLaterRegex = @"(?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で)";
+      public const string AgoLaterRegex = @"(?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で|あと)";
       public const string DurationDuringRegex = @"^[.]";
       public const string DurationSomeRegex = @"(?<few>数(?<unit>((か|ヶ)?(時|月|日(?!都合)|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)";
-      public const string DurationMoreOrLessRegex = @"(?<less>たらず)|(?<more>以上)";
+      public const string DurationMoreOrLessRegex = @"(?<less>たらず|以下|を下回る)|(?<more>以上|を上回る)";
       public const string DurationYearRegex = @"((\d{3,4})|0\d|两千)\s*年";
       public const string DurationHalfSuffixRegex = @"半";
       public static readonly Dictionary<string, string> DurationSuffixList = new Dictionary<string, string>
@@ -183,7 +183,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"M", @"分|分間" },
             { @"S", @"秒钟|秒|秒間" },
             { @"H", @"時|時間" },
-            { @"D", @"天|日|日間" },
+            { @"D", @"天|日|泊|日間" },
             { @"BD", @"営業日" },
             { @"W", @"星期|个星期|周|週間|週" },
             { @"MON", @"ひと月|月間|か月間|ヶ月|ヶ月間|个月|か月|月" },
@@ -198,15 +198,17 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"小时",
             @"天",
             @"日",
+            @"泊",
             @"星期",
             @"个星期",
             @"周",
             @"个月",
             @"年",
             @"時",
-            @"時間"
+            @"時間",
+            @"月"
         };
-      public static readonly string DurationUnitRegex = $@"(?<unit>年|个月|月|周|時間?|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)";
+      public static readonly string DurationUnitRegex = $@"(?<unit>年|个月|月|周|時間?|泊|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以[上下]|たらず|を上回る|を下回る)";
       public const string AnUnitRegex = @"(?<another>別)の?(?<unit>日|年|月|時間?)";
       public const string DurationConnectorRegex = @"^\s*(?<connector>[と]?|,)\s*$";
       public const string ConnectorRegex = @"^\s*[,-]\s*$";
@@ -239,7 +241,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string TimeCJKTimeRegex = $@"{TimeHourRegex}({TimeQuarterRegex}|({TimeHalfRegex}({TimeSecondRegex})?)|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?";
       public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?({AmPmDescRegex})?";
       public static readonly string LessTimeRegex = $@"(({TimeHourRegex}|(?<hour>{TimeHourNumRegex}):){LessThanHalfHourRegex}前)({AmPmDescRegex})?";
-      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
+      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|(早朝)?午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
       public const string TimeApproximateDescPreffixRegex = @"(ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)";
       public const string TimeApproximateDescSuffixRegex = @"(過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)";
       public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?";
@@ -291,6 +293,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"日間", @"D" },
             { @"営業日", @"BD" },
             { @"天", @"D" },
+            { @"泊", @"D" },
             { @"小时", @"H" },
             { @"時間", @"H" },
             { @"时", @"H" },
@@ -305,7 +308,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"別", @"another" },
             { @"数", @"some" },
             { @"たらず", @"less" },
-            { @"以上", @"more" }
+            { @"以上", @"more" },
+            { @"以下", @"less" },
+            { @"を上回る", @"more" },
+            { @"を下回る", @"less" }
         };
       public static readonly Dictionary<string, long> ParserConfigurationUnitValueMap = new Dictionary<string, long>
         {
@@ -681,7 +687,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         };
       public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
         {
-            { @"^今週$", @"今週" }
+            { @"^今週$", @"今週" },
+            { @"^[1一]日$", @"[1一]日" }
         };
       public static readonly Dictionary<string, string> AmbiguityDateTimeFiltersDict = new Dictionary<string, string>
         {
@@ -694,7 +701,11 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
-            { @"^(\d+|[一二三四五六七八九十廿])時間$", @"^(\d+|[一二三四五六七八九十廿])時間" }
+            { @"^(\d+|[一二三四五六七八九十廿])時$", @"(\d+|[一二三四五六七八九十廿])時間" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityTimePeriodFiltersDict = new Dictionary<string, string>
+        {
+            { @"^早$", @"早" }
         };
       public static readonly Dictionary<string, string> AmbiguityDurationFiltersDict = new Dictionary<string, string>
         {
@@ -707,7 +718,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"月間$", @"(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数ヶか ]))月間" },
             { @"週間$", @"(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))週間" },
             { @"(日|週|月|年)間?$", @"(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?" },
-            { @"^(数ヶ|数|前|昨日|以内|後|明日|もう)$", @"(数ヶ|数|前|昨日|以内|後|明日|もう)(?!\d+(か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年))" }
+            { @"^(数ヶ|数|前|昨日|以内|後|明日|もう)$", @"(数ヶ|数|前|昨日|以内|後|明日|もう)(?!\d+(か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年))" },
+            { @"^(たらず|以[下上])$", @"(たらず|以[下上])" }
         };
       public static readonly Dictionary<string, long> DurationUnitValueMap = new Dictionary<string, long>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -25,40 +25,39 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string MonthRegex = @"(?<month>(正|一|二|三|四|五|六|七|八|九|十|十一|十二|0?[1-9]|1[0-2])\s*(か月(?!で)|月間?))";
       public const string MonthRegexForPeriod = @"(?<month>正月|一月|二月|三月|四月|五月|六月|七月|八月|九月|十月|十一月|十二月|(0?[1-9]|1[0-2])か?月)(?=\b|t|まで|から)?";
       public const string MonthNumRegexForPeriod = @"(?<month>0?[1-9]|1[0-2])(?=\b|t|まで|から)?";
-      public const string DayRegex = @"(?<day>[0-2]?[1-9]|[1-3]0|31)((日|目)(?!かかる|待つ|泊まる|経つ)間?)?";
+      public const string DayRegex = @"(?<day>[0-2]?[1-9]|[1-3]0|31)((日|目)(?!かかる|待つ|泊まる|経つ|都合)間?)?";
       public const string DayRegexForPeriod = @"(?<day>3[01]|[0-2]?\d|(三十一?|(一|二)?十?[一二三四五六七八九]))((\s*日(?!かかる|待つ|泊まる|経つ))目?)?(?=\b|t|まで|から)?";
       public const string DayNumberRegex = @"(二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|二十一|三十一|十二|十三|十四|十五|十六|十七|十八|十一|十|二十|廿(?!日市市)|三十|一|二|三|四|五|六|七|八|九)";
       public static readonly string DateDayRegexInCJK = $@"(?<day>初一|({DayNumberRegex}|3[01]|[0-2]?\d)(\s*日|号)(?!かかる|待つ|泊まる|経つ))目?";
       public const string DayRegexNumInCJK = @"(?<day>一|十一|二十一|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|廿(?!日市市)|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|十|二十|廿|卅)";
       public const string MonthNumRegex = @"(?<month>0?[1-9]|1[0-2])";
       public const string TwoNumYear = @"50";
-      public const string YearNumRegex = @"((?<year>(1[5-9]|20)\d{2}|2100)(?!\$|ドル|円|¥))(\s*年)?";
-      public const string SimpleYearRegex = @"((?<year>\d{2,4})(?!\$|ドル|円|¥))(\s*年)?";
+      public const string YearNumRegex = @"((?<year>((?<!(\+\d+(-|\s)(\d+(-|\s))?(\d+(-|\s))?)|([3-9][0-9]+(-|\s)))(1[5-9]|20)\d{2})|(?<!\d+(-|\s)\d+(-|\s)\d+(-|\s))2100)(?!\$|ドル|円|¥))(\s*年)?";
+      public const string SimpleYearRegex = @"(今年)?((?<year>\d{2,4})(?!\$|ドル|円|¥))(\s*年)?";
       public const string ZeroToNineIntegerRegexCJK = @"[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨]";
       public const string DynastyStartYear = @"元";
       public const string RegionTitleRegex = @"(昭和|平成|令和|大正|明治|寛政|享和|文化|文政|天保|弘化|嘉永|安政|万延|文久|元治|慶応)";
-      public static readonly string DynastyYearRegex = $@"(?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{{1,2}}|({ZeroToNineIntegerRegexCJK}){{1,3}}))年?";
+      public static readonly string DynastyYearRegex = $@"((?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{{1,2}}|({ZeroToNineIntegerRegexCJK}){{1,3}}))年?)|(((?<Keio>慶応)|(?<Meiji>明治)|(?<Taisho>大正)|(?<Showa>昭和)|(?<Heisei>平成)|(?<Reiwa>令和))(\d+|元|{ZeroToNineIntegerRegexCJK})年)";
       public static readonly string DateYearInCJKRegex = $@"(?<yearCJK>({ZeroToNineIntegerRegexCJK}{{2,4}}|{DynastyYearRegex}))年?";
-      public static readonly string DynastyDatePeriodRegex = $@"({RegionTitleRegex}(\d{{1,2}}|{DayRegexNumInCJK})(\s*年)?({MonthRegex})?)";
       public const string WeekDayRegex = @"(週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)";
       public static readonly string WeekDayStartEnd = $@"(^(の)?{WeekDayRegex}|{WeekDayRegex}$)";
       public const string LunarRegex = @"(农历|初一|正月|大年|旧暦)";
-      public static readonly string DateThisRegex = $@"(这个|这一个|这|这一|本|(?<week>今週)|そ|こ)(的|の)?({WeekDayRegex}|日)";
+      public static readonly string DateThisRegex = $@"(这个|这一个|这|这一|本|(?<week>今週)|これ?)(的|の)?({WeekDayRegex}|日)";
       public static readonly string DateLastRegex = $@"(上一个|上个|上一|上|最后一个|最后|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)";
-      public static readonly string DateNextRegex = $@"(下一个|下个|下一|下|(?<week>来週)|次)(的|の)?{WeekDayRegex}";
+      public static readonly string DateNextRegex = $@"(下一个|下个|下一|下|(?<week>(来|翌)週)|次)(的|の)?{WeekDayRegex}";
       public static readonly string WeekWithWeekDayRangeRegex = $@"({DateThisRegex}|{DateNextRegex}|{DateLastRegex})(から)({WeekDayRegex})";
       public const string WoMLastRegex = @"過去|去|最後|先";
       public const string WoMPreviousRegex = @"前";
-      public const string WoMNextRegex = @"次|来|これから(の)?";
+      public const string WoMNextRegex = @"次|翌|来|これから(の)?";
       public const string SpecialMonthRegex = @"(先月|来月|今月|前月|再来月|昨月|先々月|ぜんげつ|(せん)?せんげつ|さくげつ|らいげつ|こんげつ)";
       public const string SpecialYearRegex = @"(ことし|さ?らいねん|きょねん|さくねん)";
-      public const string SpecialDayRegex = @"((いっ)?さくじつ|おとつい|最近|前天|后天|明日から二日((?<today>今日)から(?<half>1日半)(の間)?)|((?<today>今日)から(?<half>2日半)(の間)?)|昨日の2日前|昨日から4日|今日から二日|今日から4日|昨日から2日間|昨天|明天|今天|今日|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日|最後の日)";
-      public const string SpecialDayWithNumRegex = @"((いっ)?さくじつ|おとつい|最近|前天|后天|昨天|明天|今天|今日?|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日)(から|の)?([\d十一二三四五六七八九]*|数)(日|月|週(間で)?|個)間?(先|後|前)?(の(?<weekday>日曜日?|月曜日?|火曜日?|水曜日?|木曜日?|金曜日?|土曜日?))?";
+      public const string SpecialDayRegex = @"((いっ)?さくじつ|おとつい|最近(?!の)|前天|后天|明日から二日((?<today>今日)から(?<half>1日半)(の間)?)|((?<today>今日)から(?<half>2日半)(の間)?)|(?<today>本日)|昨日の2日前|昨日から4日|今日から二日|今日から4日|昨日から2日間|昨天|明天|今天|(?<!「)[今明]日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|(次の|翌|その|最後の)日)";
+      public const string SpecialDayWithNumRegex = @"((いっ)?さくじつ|おとつい|最近(?!の)|前天|后天|昨天|明天|今天|(?<!「)今日?|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日)(から|の)?([\d十一二三四五六七八九]*|数)(日(?!都合)|月|週(間で)?|個)間?(先|後|前)?(の(?<weekday>日曜日?|月曜日?|火曜日?|水曜日?|木曜日?|金曜日?|土曜日?))?";
       public static readonly string WeekDayOfMonthRegex = $@"((({SpecialMonthRegex}|{MonthRegex}|{MonthNumRegex}|((这个|这一个|这|这一|本|今|上个|上一个|上|上一|去|下个|下一个|下|下一|明)月))(的|の)?\s*)?(第|最)?(?<cardinal>([初一二三四五])|最後|最終|([1-5])|最后一)(个|の|\s)*{WeekDayRegex})";
       public static readonly string WeekDayAndDayRegex = $@"({DayRegexForPeriod}(の|的)?(\s|,)*{WeekDayRegex})";
       public const string ThisPrefixRegex = @"这个|这一个|这|这一|本|今|こ";
-      public const string LastPrefixRegex = @"上个|上一个|上|上一|去|過去|最後|前|先|昨|最終";
-      public const string NextPrefixRegex = @"下个|下一个|下|下一|明|次|再?来|向こう|これから(の)?|翌|向こう";
+      public const string LastPrefixRegex = @"上个|上一个|上|上一|去|過去|ここ|最後|前|先|昨|最終";
+      public const string NextPrefixRegex = @"下个|下一个|下|下一|明(?!治)|次|再?来|向こう|これから(の)?|翌|向こう";
       public static readonly string RelativeRegex = $@"(?<order>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex}))";
       public static readonly string SpecialDate = $@"(?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})年)?(の|的)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})(の|的)?月)?(の|的)?{DateDayRegexInCJK}";
       public const string DateUnitRegex = @"(?<unit>年|个月|月|周|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)";
@@ -67,7 +66,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string TimePeriodLeftRegex = @"あと";
       public static readonly string DateRegexList1 = $@"({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,)*{WeekDayRegex})?)";
       public static readonly string DateRegexList2 = $@"(({SimpleYearRegex}|{DateYearInCJKRegex}){MonthRegexForPeriod}\s*)";
-      public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?(から)?";
+      public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?";
       public static readonly string DateRegexList4 = $@"(?<!\d){MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\d*%)((\s+|\s*,\s*)({SimpleYearRegex}|{DateYearInCJKRegex}))?((\s|,)*{WeekDayRegex})?(?!\d)";
       public static readonly string DateRegexList5 = $@"(?<!\d){DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}(?!\d*%)((\s+|\s*,\s*)({SimpleYearRegex}|{DateYearInCJKRegex}))?((\s|,)*{WeekDayRegex})?(?!\d)";
       public static readonly string DateRegexList6 = $@"{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*({SimpleYearRegex}|{DateYearInCJKRegex})";
@@ -76,30 +75,30 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string DateRegexList9 = $@"({LunarRegex}(的|の|\s)*)?((\s*{MonthRegex}[/\\\-の的]?{DayRegexForPeriod}((\s|,)*{WeekDayRegex})?)|((\s*{MonthRegex}[/\\\-の的]?){DayRegexForPeriod}(の|的)?((\s|,)*{WeekDayRegex})))";
       public static readonly string DateRegexList10 = $@"(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-]{MonthNumRegex}[/\\\-]{DayRegexForPeriod})";
       public static readonly string DateRegexList11 = $@"(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-]{MonthNumRegexForPeriod})";
-      public const string DatePeriodTillRegex = @"(?<till>到|至|から|--|-|—|——|~|–)";
-      public const string DatePeriodRangeSuffixRegex = @"^\b$";
+      public const string DatePeriodTillRegex = @"(?<till>到|至|から|--|-|—|——|~|–)(?!\d泊)";
+      public const string DatePeriodRangeSuffixRegex = @"(に?まで|の間)";
       public const string DatePeriodRangePrefixRegex = @"^\b$";
       public const string DatePeriodTillSuffixRequiredRegex = @"(?<till>与|和)";
       public const string DatePeriodDayRegexInCJK = @"(?<day>(二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|二十二|二十三|二十一|十一|三十一|十二|十三|十四|十五|十六|十七|十八|十九|十|二十|三十|一|十|二|三|四|五|六|七|八|九|3[0-1]|[1-2]\d|0?[1-9])日|初一|三十|(一|十一|二十一|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|十|二十|三十|3[0-1]|[1-2]\d|0?[1-9])号|一|十一|二十一|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|十|二十|三十|廿(?!日市市)|卅)目?";
-      public const string DatePeriodThisRegex = @"今|这个|这一个|这|这一|本";
-      public const string DatePeriodLastRegex = @"この|上个|上一个|上|上一|前|去|最後|最終|過去|先|昨";
-      public const string DatePeriodNextRegex = @"(?<after>再来|以降)|下个|下一个|下|下一|最初|来|向こう|これから(の)?|翌|今後|次(の)?";
-      public const string DateRangePrepositions = @"((こ|私の|その|この|これらの|それらの)\s*)?";
+      public const string DatePeriodThisRegex = @"(?<!「)今|这个|这一个|这|这一|本";
+      public const string DatePeriodLastRegex = @"この|上个|上一个|上|上一|前|去|最後|最終|過去|ここ|先|昨|前";
+      public const string DatePeriodNextRegex = @"(?<after>再来|以降)|下个|下一个|下|下一|最初|来|向こう|これから(の)?|翌|今後|次(の)?|の後";
+      public const string DateRangePrepositions = @"((ひと|こ|私の|その|この|これらの|それらの)\s*)?";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)";
-      public const string HalfYearRegex = @"((?<firstHalf>の?(上|前)半期)|(?<secondHalf>の?(下|后)半期))";
-      public static readonly string YearRegex = $@"(({YearNumRegex})(\s*年)?|({SimpleYearRegex})\s*年)(に)?{HalfYearRegex}?";
-      public static readonly string StrictYearRegex = $@"(((こ|その|この|これらの|それらの)\s*)?{YearRegex})";
+      public const string HalfYearRegex = @"((?<firstHalf>の?(上|前)半期?)|(?<secondHalf>の?(下|后|後)半期?))";
+      public static readonly string YearRegex = $@"((({YearNumRegex})(\s*年)?|({SimpleYearRegex})\s*年)(に)?{HalfYearRegex}?)|({DynastyYearRegex})";
+      public static readonly string StrictYearRegex = $@"(((ひと|こ|その|この|これらの|それらの)\s*)?{YearRegex})";
       public const string YearRegexInNumber = @"(?<year>(\d{3,4}))";
       public static readonly string DatePeriodYearInCJKRegex = $@"(?<yearCJK>({ZeroToNineIntegerRegexCJK}{{2,4}}))年{HalfYearRegex}?";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>({RelativeMonthRegex}|{MonthRegex}))";
-      public static readonly string SimpleCasesRegex = $@"({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex})\s*)?{MonthSuffixRegex}({DatePeriodDayRegexInCJK}|{DayRegex})\s*{DatePeriodTillRegex}\s*({DatePeriodDayRegexInCJK}|{DayRegex})((\s+|\s*,\s*){YearRegex})?(までの間|まで|の間)?";
-      public static readonly string YearAndMonth = $@"({YearNumRegex}の?\s*{MonthRegex}(\b|から)?)";
+      public static readonly string SimpleCasesRegex = $@"({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex})\s*)?{MonthSuffixRegex}({DatePeriodDayRegexInCJK}|{DayRegex})\s*{DatePeriodTillRegex}\s*({DatePeriodDayRegexInCJK}|{DayRegex})(?!\d)((\s+|\s*,\s*){YearRegex})?(までの間|まで|の間)?";
+      public static readonly string YearAndMonth = $@"(({YearNumRegex}|{DateYearInCJKRegex})の?\s*{MonthRegex}(\b|から)?)";
       public static readonly string SimpleYearAndMonth = $@"({DateRangePrepositions})({YearNumRegex}[/\\\-]{MonthNumRegex}(\b|から)$)";
-      public static readonly string PureNumYearAndMonth = $@"({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})";
-      public static readonly string OneWordPeriodRegex = $@"({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>今年|再来年|翌年|去年|前年|后年|来年))(,|の(残り)?)?\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?の?\s*(数|\d\d?|{ZeroToNineIntegerRegexCJK})?(?<duration>ヶ?((?<!休|建国記念)日(?!付)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|週(間)?|年(?!々)(間)?|週間|今年|再来年|翌年|去年|前年|后年|来年))(?!間で)(?!で))(?<restof>の残りの日|いっぱい)?|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?";
-      public const string LaterEarlyPeriodRegex = @"((?<next>来)|(?<this>今|同じ)|(?<last>この|去|先))?(?<suffix>(?<!建国記念)日(?!付)|(?<month>(\d))?((?<!((?<![1-9]+)0+))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>半ば)|(?<EarlyPrefix>(の)?初め|のはじめ|初旬|(?<RelEarly>ちょっと前に|上旬に))|(?<!の休日))";
+      public static readonly string PureNumYearAndMonth = $@"({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})(?!\d)|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})";
+      public static readonly string OneWordPeriodRegex = $@"({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<!休|建国記念)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?";
+      public const string LaterEarlyPeriodRegex = @"((?<next>来|翌)|(?<this>今|同じ)|(?<last>この|去|先|前(の)?))?(?<suffix>(?<!建国記念)日(?!付)|(?<week>週(間)?)|(?<month>(正|一|二|三|四|五|六|七|八|九|十|十一|十二|0?[1-9]|1[0-2]))?((?<!((?<![1-9])0))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々|齢)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後|の後半)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>(の)?(半ば|中旬))|(?<EarlyPrefix>(の)?初め|のはじめ|早くに|初旬|(?<RelEarly>ちょっと前に|上旬(に)?)))";
       public const string DatePointWithAgoAndLater = @"((?<today>今日)|(?<yesterday>昨日)|(?<tomorrow>明日))(から|の)(\d)(?<duration>週間|日)((?<within>以内)|(?<more>以上)(?<ago>前)|(?<more>以上(あと)?))";
-      public static readonly string WeekOfMonthRegex = $@"({DateRangePrepositions})((?<wom>{MonthSuffixRegex}(的|の))(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)";
+      public static readonly string WeekOfMonthRegex = $@"({DateRangePrepositions})((?<wom>({YearRegex}\s*)?{MonthSuffixRegex}(的|の))(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)";
       public static readonly string WeekOfYearRegex = $@"({DateRangePrepositions})(?<woy>({YearRegex}|{RelativeRegex}年)(的|の)(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)";
       public static readonly string WeekOfDateRegex = $@"(({DateRangePrepositions})({MonthSuffixRegex}({DayRegex})(的|の))第?\s*の?(週|周)s*)|({DayRegex}日の?(週(間)?))";
       public static readonly string MonthOfDateRegex = $@"({DateRangePrepositions})({MonthSuffixRegex}({DayRegex})(的|の))第?\s*の?(月)s*";
@@ -116,62 +115,66 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string MonthToMonthSuffixRequired = @"^[.]";
       public static readonly string DayToDay = $@"({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?(({SpecialMonthRegex}|{MonthRegex})の?)?(({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})から(({SpecialMonthRegex}|{MonthRegex})の?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?((今月|来月|{MonthRegex})の?)?({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})(までの間|まで|の間))|{SpecialDayRegex}";
       public static readonly string FirstLastOfYearRegex = $@"(({DatePeriodYearInCJKRegex}|{YearRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))的?)((?<first>前)|(?<last>(最后|最後|最終)))";
-      public static readonly string ComplexDatePeriodRegex = $@"({DateRangePrepositions})(?<start>(第{ZeroToNineIntegerRegexCJK}+|第\d+|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex}|(({YearNumRegex}|{DayRegexForPeriod}|{DateDayRegexInCJK}|{MonthRegex}|{MonthNumRegex})(?!((\d+)?(分|秒|時))))|{RelativeRegex}).+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)";
-      public const string PastRegex = @"(?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|過去)(の)?)";
-      public const string FutureRegex = @"(?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これからの|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))";
-      public const string SeasonRegex = @"(?<season>春|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?";
+      public static readonly string ComplexDatePeriodRegex = $@"({DateRangePrepositions})(?<start>.+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)";
+      public const string PastRegex = @"(?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)";
+      public const string FutureRegex = @"(?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これから(の)?|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))";
+      public const string SeasonRegex = @"(?<season>春(?!節)|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?";
       public const string WhichWeekRegex = @"第(?<number>5[0-3]|[1-4]\d|0?[1-9])週";
       public static readonly string SeasonWithYear = $@"({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?{SeasonRegex}";
-      public static readonly string QuarterRegex = $@"({DateRangePrepositions})((({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)?(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)?))|(({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex})(四半期|クォーター))";
+      public static readonly string QuarterRegex = $@"({DateRangePrepositions})((({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)?)|(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)))|(({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex})(四半期|クォーター))";
       public const string CenturyNumRegex = @"(?<century>\d|1\d|2\d)世紀";
       public const string CenturyRegexInCJK = @"(?<century>一|二|三|四|五|六|七|八|九|十|十一|十二|十三|十四|十五|十六|十七|十八|十九|二十|二十一|二十二)世紀";
       public static readonly string CenturyRegex = $@"({CenturyNumRegex}|{CenturyRegexInCJK})";
       public static readonly string RelativeCenturyRegex = $@"(?<relcentury>({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex}))世紀";
       public const string DecadeRegexInCJK = @"(?<decade>十|一十|二十|三十|四十|五十|六十|七十|八十|九十)";
       public static readonly string DecadeRegex = $@"({DateRangePrepositions})(?<centurysuf>({CenturyRegex}|{CenturyRegexInCJK}|{RelativeCenturyRegex}))?の?(?<firsttwoyearnum>\d{{2}}(?=\d))?(?<decade>((\d{{1}}0)|{DecadeRegexInCJK}))年代(のごろ)?";
-      public const string PrepositionRegex = @"(?<prep>^(,?(夜の|的|の|t))|在$)";
-      public const string NowRegex = @"(?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(すぐ)?)";
-      public const string NightRegex = @"(?<night>早|晚|夜)";
-      public const string TomorrowRegex = @"(?<tomorrow>明日の?(午前|午後|中|夜|朝)?)";
-      public const string YesterdayRegex = @"(?<yesterday>昨日の?(午前|午後|中|夜|朝)?)";
+      public const string PrepositionRegex = @"(?<prep>^(,?(夜の|的|の(?<timeOfDay>朝|夜|午後|晩)?|t),?|在)$)";
+      public const string NowRegex = @"(?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(?!日)(すぐ)?)";
+      public const string NightRegex = @"(?<night>早|晚|夜|泊(?=の?予約))";
+      public const string TomorrowRegex = @"(?<tomorrow>(?<!「)明日の?(午前|午後|中|夜|泊(?=の?予約)|朝)?)";
+      public const string YesterdayRegex = @"(?<yesterday>昨日の?(午前|午後|中|夜|泊(?=の?予約)|朝)?)";
       public const string TodayRegex = @"(?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)";
       public const string FromNowRegex = @"((?<now>今)から)";
       public static readonly string SpecialDayHourRegex = $@"((?<hour>{TimeHourCJKRegex}|{TimeHourNumRegex})(時間?|(:00)))";
       public static readonly string SpecialDayMinuteRegex = $@"((?<min>{TimeMinuteCJKRegex}|{TimeMinuteNumRegex})分間?)";
       public static readonly string SpecialDaySecondRegex = $@"((?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex})秒間?)";
-      public const string SpecialDayModRegex = @"((?<after>過ぎに|以降)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))";
-      public static readonly string SpecialDayEndOfRegex = $@"((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))";
+      public const string SpecialDayModRegex = @"((?<after>過ぎに|以降)|(?<in>で)|(?<less>弱|たらず)|(?<more>以上))";
+      public static readonly string SpecialDayEndOfRegex = $@"((?<SpecificEndOf>明日の終わり|今?({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))";
       public static readonly string TimeOfSpecialDayRegex = $@"(({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)";
       public const string NowTimeRegex = @"(现在|今)";
       public const string RecentlyTimeRegex = @"(刚刚才?|刚才)";
       public const string AsapTimeRegex = @"(出来る限り早く|立刻|马上)";
       public const string DateTimePeriodTillRegex = @"(?<till> 到|至|から|--|-|—|——|~)";
-      public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*(的|の(?!午))|在\s*$)";
+      public const string DateTimePeriodFromPrefixRegex = @"(从)";
+      public const string DateTimePeriodFromSuffixRegex = @"(の間|まで(の間)?)";
+      public const string DateTimePeriodConnectorRegex = @"(和|与|到)";
+      public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*(的|の(?!午)|在)\s*$)";
+      public const string BeforeAfterRegex = @"(前|後)";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string HourNumRegex = @"(?<hour>[零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)";
       public const string ZhijianRegex = @"^\s*(之间|之内|期间|中间|间)";
       public const string DateTimePeriodThisRegex = @"这个|这一个|这|这一|今後|今から|これから";
       public const string DateTimePeriodLastRegex = @"上个|上一个|上|上一|昨";
       public const string DateTimePeriodNextRegex = @"下个|下一个|下|下一";
-      public const string AmPmDescRegex = @"(?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))";
-      public const string TimeOfDayRegex = @"(?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|日|号)晩(?!上))";
-      public static readonly string SpecificTimeOfDayRegex = $@"((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))";
+      public const string AmPmDescRegex = @"(?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m|夜|晚|晩|午後|午后|午前(半ば|中)?|正午|真昼|夜中|深夜|昼食時|夕方に|朝|午後|昼(?!食)))";
+      public const string TimeOfDayRegex = @"(?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|泊(?=の?予約)|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|泊(?=の?予約)|日|号)晩(?!上))";
+      public static readonly string SpecificTimeOfDayRegex = $@"((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|泊(?=の?予約)|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))";
       public const string DateTimePeriodUnitRegex = @"(?<unit>(時|分|秒)間?)";
       public static readonly string DateTimePeriodFollowedUnit = $@"^\s*{DateTimePeriodUnitRegex}";
       public static readonly string DateTimePeriodNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){DateTimePeriodUnitRegex}";
-      public const string PlusOneDayRegex = @"あす|あした|明日|来|次";
+      public const string PlusOneDayRegex = @"あす|あした|明日|来|次|翌";
       public const string MinusOneDayRegex = @"きのう|最後の日|前日|昨|昨日の?";
       public const string PlusTwoDayRegex = @"后天|後天|明後日|あさって|今日から二日";
       public const string MinusTwoDayRegex = @"前天|一昨日|二日前|おととい";
       public const string PlusThreeDayRegex = @"大后天|大後天|明日から二日|昨日から4日";
       public const string MinusThreeDayRegex = @"大前天|昨日の2日前|昨日から2日間";
       public const string PlusFourDayRegex = @"今日から4日";
-      public const string DurationAllRegex = @"(まる(ひと)?)";
+      public const string DurationAllRegex = @"(まる)";
       public const string DurationHalfRegex = @"^[.]";
-      public const string DurationRelativeDurationUnitRegex = @"(?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|明日)|(?<another>(?<!に)もう)";
-      public const string AgoLaterRegex = @"(?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後)";
+      public const string DurationRelativeDurationUnitRegex = @"(?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|(?<!「)明日)|(?<another>(?<!(に))もう(?=\d)|別)の?(日|週|月)?";
+      public const string AgoLaterRegex = @"(?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で)";
       public const string DurationDuringRegex = @"^[.]";
-      public const string DurationSomeRegex = @"(?<few>数(?<unit>((か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)";
+      public const string DurationSomeRegex = @"(?<few>数(?<unit>((か|ヶ)?(時|月|日(?!都合)|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)";
       public const string DurationMoreOrLessRegex = @"(?<less>たらず)|(?<more>以上)";
       public const string DurationYearRegex = @"((\d{3,4})|0\d|两千)\s*年";
       public const string DurationHalfSuffixRegex = @"半";
@@ -183,7 +186,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"D", @"天|日|日間" },
             { @"BD", @"営業日" },
             { @"W", @"星期|个星期|周|週間|週" },
-            { @"MON", @"个月|か月|月|月間|か月間|ヶ月|ヶ月間" },
+            { @"MON", @"ひと月|月間|か月間|ヶ月|ヶ月間|个月|か月|月" },
             { @"Y", @"年|年間" }
         };
       public static readonly IList<string> DurationAmbiguousUnits = new List<string>
@@ -199,16 +202,19 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"个星期",
             @"周",
             @"个月",
-            @"年"
+            @"年",
+            @"時",
+            @"時間"
         };
       public static readonly string DurationUnitRegex = $@"(?<unit>年|个月|月|周|時間?|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)";
+      public const string AnUnitRegex = @"(?<another>別)の?(?<unit>日|年|月|時間?)";
       public const string DurationConnectorRegex = @"^\s*(?<connector>[と]?|,)\s*$";
       public const string ConnectorRegex = @"^\s*[,-]\s*$";
       public static readonly string LunarHolidayRegex = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>除夕|春节|旧暦の正月初一|中秋(節|节)?|元宵(节|節)|端午(节|の節句)?|重(阳节|陽節))";
-      public static readonly string HolidayRegexList1 = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)";
+      public static readonly string HolidayRegexList1 = $@"(旧暦の)?(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|の?独立記念日|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)(の\d日)?";
       public static readonly string HolidayRegexList2 = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>母(亲节|の日)|父亲节|感恩节|万圣节|ハロウィン)";
       public const string SetUnitRegex = @"(?<unit>年|月|隔週|週|日|時|分|秒)";
-      public static readonly string SetEachUnitRegex = $@"((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<=\d)泊|(?<unit>隔週))";
+      public static readonly string SetEachUnitRegex = $@"((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<unit>隔週))";
       public const string SetEachPrefixRegex = @"((?<each>毎|隔|各|ごとに)\s*$)";
       public const string SetEachSuffixRegex = @"(^\s*(?<each>ごとに))";
       public const string SetLastRegex = @"(?<last>last|this|next)";
@@ -229,14 +235,16 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string TimeSecondRegex = $@"(?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex}){TimeSecondDescRegex}";
       public const string TimeHalfRegex = @"(?<half>过半|半)";
       public const string TimeQuarterRegex = @"(?<quarter>[一两二三四1-4])\s*(刻钟|刻)";
-      public static readonly string TimeCJKTimeRegex = $@"{TimeHourRegex}({TimeQuarterRegex}|{TimeHalfRegex}|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?";
+      public static readonly string LessThanHalfHourRegex = $@"(?<min>([0-2]?\d)|(二?十[一二三四五六七八九]?|[零〇一二三四五六七八九]))({TimeMinuteDescRegex})";
+      public static readonly string TimeCJKTimeRegex = $@"{TimeHourRegex}({TimeQuarterRegex}|({TimeHalfRegex}({TimeSecondRegex})?)|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?";
       public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?({AmPmDescRegex})?";
-      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
+      public static readonly string LessTimeRegex = $@"(({TimeHourRegex}|(?<hour>{TimeHourNumRegex}):){LessThanHalfHourRegex}前)({AmPmDescRegex})?";
+      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
       public const string TimeApproximateDescPreffixRegex = @"(ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)";
-      public const string TimeApproximateDescSuffixRegex = @"(ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり|以降|まで(の間)?|の間|間で?|間以内)";
+      public const string TimeApproximateDescSuffixRegex = @"(過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)";
       public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?";
       public static readonly string TimeRegexes2 = $@"({TimeApproximateDescPreffixRegex}(の)?)?{TimeDayDescRegex}((の)?{TimeApproximateDescSuffixRegex})?";
-      public static readonly string TimeRegexes3 = $@"({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})前((の)?{TimeDayDescRegex})?";
+      public static readonly string TimeRegexes3 = $@"({TimeDayDescRegex}(の)?)?({LessTimeRegex})((の)?{TimeDayDescRegex})?";
       public const string TimePeriodTimePeriodConnectWords = @"(まで(の間)?|の間|–|-|—|~|～)";
       public static readonly string TimePeriodLeftCJKTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeCJKTimeRegex}))(から)?";
       public static readonly string TimePeriodRightCJKTimeRegex = $@"{TimePeriodTimePeriodConnectWords}?(?<right>{TimeDayDescRegex}?{TimeCJKTimeRegex}){TimePeriodTimePeriodConnectWords}?";
@@ -245,15 +253,18 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string TimePeriodShortLeftCJKTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeHourCJKRegex}))(から)?";
       public static readonly string TimePeriodShortLeftDigitTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeHourNumRegex}))(から)?";
       public static readonly string TimePeriodRegexes1 = $@"({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})";
-      public static readonly string TimePeriodRegexes2 = $@"(((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))";
+      public static readonly string TimePeriodRegexes2 = $@"(((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))";
       public const string FromToRegex = @"^[.]";
       public const string AmbiguousRangeModifierPrefix = @"^[.]";
+      public const string UnspecificDatePeriodRegex = @"^(の?(分|日|週|周|月|年|時間))$";
       public const string ReferenceDatePeriodRegex = @"(同じ|その)(?<duration>月|週末|年|週)";
-      public const string ParserConfigurationBefore = @"(またはその前|またはそれ以前|之前|以前|前)";
-      public const string ParserConfigurationAfter = @"(またはそれ以降|之后|之後|以后|以後|后|後|以降)";
-      public const string ParserConfigurationUntil = @"(まで|直到|直至|截至|截止(到)?)";
-      public const string ParserConfigurationSincePrefix = @"(自从|自|自打|打)";
-      public const string ParserConfigurationSinceSuffix = @"(以来|开始)";
+      public const string ParserConfigurationBefore = @"((?<include>(または|及び|と)そ)?の前|またはそれ以前|之前|以前|前|まで|以前)";
+      public const string ParserConfigurationAfter = @"(の後から|(?<include>または)それ以降|之后|之後|以后|以後|后|の?後|以降)";
+      public const string ParserConfigurationUntil = @"(直到|直至|截至|截止(到)?)";
+      public const string ParserConfigurationSincePrefix = @"(自从|自|自打|打|早ければ)";
+      public const string ParserConfigurationSinceSuffix = @"(またはその後|以来|开始|(?<!の後)から(?!\d(時|分|秒|月|日|\d?泊)))";
+      public const string ParserConfigurationAroundPrefix = @"(ごろ|頃)";
+      public const string ParserConfigurationAroundSuffix = @"(頃|ごろ)";
       public const string ParserConfigurationLastWeekDayRegex = @"最后一个";
       public const string ParserConfigurationNextMonthRegex = @"来月";
       public const string ParserConfigurationAfterNextMonthRegex = @"再来月";
@@ -291,6 +302,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"まる", @"whole" },
             { @"まるひと", @"whole" },
             { @"もう", @"another" },
+            { @"別", @"another" },
             { @"数", @"some" },
             { @"たらず", @"less" },
             { @"以上", @"more" }
@@ -321,7 +333,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         };
       public static readonly IList<string> MonthTerms = new List<string>
         {
-            @"月"
+            @"月",
+            @"月間",
+            @"月の前半",
+            @"月の後半"
         };
       public static readonly IList<string> WeekendTerms = new List<string>
         {
@@ -333,20 +348,30 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         {
             @"周",
             @"週",
-            @"週間"
+            @"週間",
+            @"週の前半",
+            @"週の後半"
         };
       public static readonly IList<string> YearTerms = new List<string>
         {
             @"年",
-            @"年間"
+            @"年間",
+            @"去年",
+            @"今年",
+            @"来年"
         };
       public static readonly IList<string> ThisYearTerms = new List<string>
         {
             @"今年"
         };
+      public static readonly IList<string> YearToDateTerms = new List<string>
+        {
+            @"年初来"
+        };
       public static readonly IList<string> LastYearTerms = new List<string>
         {
-            @"去年"
+            @"去年",
+            @"前の年"
         };
       public static readonly IList<string> NextYearTerms = new List<string>
         {
@@ -380,6 +405,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         {
             { @"一", 1 },
             { @"初", 1 },
+            { @"最初", 1 },
             { @"二", 2 },
             { @"三", 3 },
             { @"四", 4 },
@@ -607,6 +633,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"十月", 10 },
             { @"十一月", 11 },
             { @"十二月", 12 },
+            { @"正月", 13 },
             { @"1月", 1 },
             { @"2月", 2 },
             { @"3月", 3 },
@@ -644,22 +671,43 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string DateTimeSimpleAmRegex = @"(?<am>早|晨|am)";
       public const string DateTimeSimplePmRegex = @"(?<pm>晚|晩|pm)";
       public const string DateTimePeriodMORegex = @"(朝|凌晨|清晨|早上|早|上午)";
-      public const string DateTimePeriodMIRegex = @"^[.]";
+      public const string DateTimePeriodMIRegex = @"昼(?!食)";
       public const string DateTimePeriodAFRegex = @"(中午|下午|午后|傍晚)";
       public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚|晩)";
-      public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜|夜)";
+      public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜|夜|泊(?=の?予約))";
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"早", @"(?<!今|明|日|号)早(?!上)" },
             { @"^\d{1,2}\.\d{1,2}$", @"\d{1,2}\.\d{1,2}(?!\s*に[戻残]|から|で)" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
+        {
+            { @"^今週$", @"今週" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"から.+まで", @"" }
         };
       public static readonly Dictionary<string, string> AmbiguityDatePeriodFiltersDict = new Dictionary<string, string>
         {
-            { @"^年$", @"年" }
+            { @"^年$", @"年" },
+            { @"(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?", @"(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"^(\d+|[一二三四五六七八九十廿])時間$", @"^(\d+|[一二三四五六七八九十廿])時間" }
         };
       public static readonly Dictionary<string, string> AmbiguityDurationFiltersDict = new Dictionary<string, string>
         {
-            { @"月に", @"月に" }
+            { @"月", @"(?<!ヶ|か|まるひと|もう1か)月(?!間|前|後)" },
+            { @"月に", @"月に" },
+            { @"月から", @"月から" },
+            { @"^十分$", @"十分(?!前|後)" },
+            { @"時間をつくっ", @"時間をつくっ" },
+            { @"年間$", @"(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))年間" },
+            { @"月間$", @"(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数ヶか ]))月間" },
+            { @"週間$", @"(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))週間" },
+            { @"(日|週|月|年)間?$", @"(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?" },
+            { @"^(数ヶ|数|前|昨日|以内|後|明日|もう)$", @"(数ヶ|数|前|昨日|以内|後|明日|もう)(?!\d+(か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年))" }
         };
       public static readonly Dictionary<string, long> DurationUnitValueMap = new Dictionary<string, long>
         {
@@ -709,6 +757,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
         };
       public static readonly Dictionary<string, int> TimeLowBoundDesc = new Dictionary<string, int>
         {
+            { @"泊", 18 },
             { @"夜", 18 },
             { @"晚", 18 },
             { @"晩", 18 },
@@ -773,6 +822,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"深夜",
             @"夜に",
             @"夜",
+            @"泊",
             @"夜中",
             @"夜間"
         };
@@ -812,7 +862,169 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"万延", 1860 },
             { @"文久", 1861 },
             { @"元治", 1864 },
-            { @"慶応", 1865 }
+            { @"慶応", 1865 },
+            { @"平成二", 1990 },
+            { @"平成元", 1989 },
+            { @"昭和二", 1927 },
+            { @"大正二", 1913 },
+            { @"大正元", 1912 },
+            { @"慶応4", 1868 },
+            { @"明治元", 1868 },
+            { @"明治2", 1869 },
+            { @"明治3", 1870 },
+            { @"明治4", 1871 },
+            { @"明治5", 1872 },
+            { @"明治6", 1873 },
+            { @"明治7", 1874 },
+            { @"明治8", 1875 },
+            { @"明治9", 1876 },
+            { @"明治10", 1877 },
+            { @"明治11", 1878 },
+            { @"明治12", 1879 },
+            { @"明治13", 1880 },
+            { @"明治14", 1881 },
+            { @"明治15", 1882 },
+            { @"明治16", 1883 },
+            { @"明治17", 1884 },
+            { @"明治18", 1885 },
+            { @"明治19", 1886 },
+            { @"明治20", 1887 },
+            { @"明治21", 1888 },
+            { @"明治22", 1889 },
+            { @"明治23", 1890 },
+            { @"明治24", 1891 },
+            { @"明治25", 1892 },
+            { @"明治26", 1893 },
+            { @"明治27", 1894 },
+            { @"明治28", 1895 },
+            { @"明治29", 1896 },
+            { @"明治30", 1897 },
+            { @"明治31", 1898 },
+            { @"明治32", 1899 },
+            { @"明治33", 1900 },
+            { @"明治34", 1901 },
+            { @"明治35", 1902 },
+            { @"明治36", 1903 },
+            { @"明治37", 1904 },
+            { @"明治38", 1905 },
+            { @"明治39", 1906 },
+            { @"明治40", 1907 },
+            { @"明治41", 1908 },
+            { @"明治42", 1909 },
+            { @"明治43", 1910 },
+            { @"明治44", 1911 },
+            { @"明治45", 1912 },
+            { @"大正2", 1913 },
+            { @"大正3", 1914 },
+            { @"大正4", 1915 },
+            { @"大正5", 1916 },
+            { @"大正6", 1917 },
+            { @"大正7", 1918 },
+            { @"大正8", 1919 },
+            { @"大正9", 1920 },
+            { @"大正10", 1921 },
+            { @"大正11", 1922 },
+            { @"大正12", 1923 },
+            { @"大正13", 1924 },
+            { @"大正14", 1925 },
+            { @"大正15", 1926 },
+            { @"昭和元", 1926 },
+            { @"昭和64", 1989 },
+            { @"昭和2", 1927 },
+            { @"昭和3", 1928 },
+            { @"昭和4", 1929 },
+            { @"昭和5", 1930 },
+            { @"昭和6", 1931 },
+            { @"昭和7", 1932 },
+            { @"昭和8", 1933 },
+            { @"昭和9", 1934 },
+            { @"昭和10", 1935 },
+            { @"昭和11", 1936 },
+            { @"昭和12", 1937 },
+            { @"昭和13", 1938 },
+            { @"昭和14", 1939 },
+            { @"昭和15", 1940 },
+            { @"昭和16", 1941 },
+            { @"昭和17", 1942 },
+            { @"昭和18", 1943 },
+            { @"昭和19", 1944 },
+            { @"昭和20", 1945 },
+            { @"昭和21", 1946 },
+            { @"昭和22", 1947 },
+            { @"昭和23", 1948 },
+            { @"昭和24", 1949 },
+            { @"昭和25", 1950 },
+            { @"昭和26", 1951 },
+            { @"昭和27", 1952 },
+            { @"昭和28", 1953 },
+            { @"昭和29", 1954 },
+            { @"昭和30", 1955 },
+            { @"昭和31", 1956 },
+            { @"昭和32", 1957 },
+            { @"昭和33", 1958 },
+            { @"昭和34", 1959 },
+            { @"昭和35", 1960 },
+            { @"昭和36", 1961 },
+            { @"昭和37", 1962 },
+            { @"昭和38", 1963 },
+            { @"昭和39", 1964 },
+            { @"昭和40", 1965 },
+            { @"昭和41", 1966 },
+            { @"昭和42", 1967 },
+            { @"昭和43", 1968 },
+            { @"昭和44", 1969 },
+            { @"昭和45", 1970 },
+            { @"昭和46", 1971 },
+            { @"昭和47", 1972 },
+            { @"昭和48", 1973 },
+            { @"昭和49", 1974 },
+            { @"昭和50", 1975 },
+            { @"昭和51", 1976 },
+            { @"昭和52", 1977 },
+            { @"昭和53", 1978 },
+            { @"昭和54", 1979 },
+            { @"昭和55", 1980 },
+            { @"昭和56", 1981 },
+            { @"昭和57", 1982 },
+            { @"昭和58", 1983 },
+            { @"昭和59", 1984 },
+            { @"昭和60", 1985 },
+            { @"昭和61", 1986 },
+            { @"昭和62", 1987 },
+            { @"昭和63", 1988 },
+            { @"平成2", 1990 },
+            { @"平成3", 1991 },
+            { @"平成4", 1992 },
+            { @"平成5", 1993 },
+            { @"平成6", 1994 },
+            { @"平成7", 1995 },
+            { @"平成8", 1996 },
+            { @"平成9", 1997 },
+            { @"平成10", 1998 },
+            { @"平成11", 1999 },
+            { @"平成12", 2000 },
+            { @"平成13", 2001 },
+            { @"平成14", 2002 },
+            { @"平成15", 2003 },
+            { @"平成16", 2004 },
+            { @"平成17", 2005 },
+            { @"平成18", 2006 },
+            { @"平成19", 2007 },
+            { @"平成20", 2008 },
+            { @"平成21", 2009 },
+            { @"平成22", 2010 },
+            { @"平成23", 2011 },
+            { @"平成24", 2012 },
+            { @"平成25", 2013 },
+            { @"平成26", 2014 },
+            { @"平成27", 2015 },
+            { @"平成28", 2016 },
+            { @"平成29", 2017 },
+            { @"平成30", 2018 },
+            { @"平成31", 2019 },
+            { @"令和元", 2019 },
+            { @"令和2", 2020 },
+            { @"令和3", 2021 }
         };
       public const string DayTypeRegex = @"^(天|日)$";
       public const string WeekTypeRegex = @"^(周|星期|週)$";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
@@ -693,6 +693,10 @@ namespace Microsoft.Recognizers.Definitions.Korean
         {
             { @"^[.]", @"^[.]" }
         };
+      public static readonly Dictionary<string, string> AmbiguityTimePeriodFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
       public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
         {
             { @"^[.]", @"^[.]" }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string TimeOfSpecialDayRegex = @"(今晚|今早|今晨|明晚|明早|明晨|昨晚)(的|在)?";
       public const string DateTimePeriodTillRegex = @"(?<till>到|直到|--|-|—|——)";
       public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*的|在\s*$)";
+      public const string BeforeAfterRegex = @"^\b$";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string HourNumRegex = @"(?<hour>[한두세네]|다섯|여섯|일곱|여덟|아홉|스무|스물[한두세네]|열([한두세네]|다섯|여섯|일곱|여덟|아홉)?)";
       public const string ZhijianRegex = @"^\s*(까지)";
@@ -189,6 +190,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
             @"시"
         };
       public const string DurationUnitRegex = @"(?<unit>(년|개?월|달|주일?|(?<!종)(?<=\d|\s+)일|(?<=\s)날|한나절|(?<=며)칠|시간?|분|초|영업일\s*기준으로|하루|이틀|사흘|나흘|닷새|엿새|이레|여드레|아흐레|열흘|하루|종일|내내|몇|여러|더|이상|이하|초과|미만)\s*(이상|이하|초과|미만)?)";
+      public const string AnUnitRegex = @"^[.]";
       public const string DurationConnectorRegex = @"(?<connector>\s*그리고\s*|\s+|,\s*)";
       public const string ConnectorRegex = @"^\s*,\s*$";
       public static readonly string DurationMoreOrLessThanSurfix = $@"(?<DurationUnitRegex>\s*(이상|이하|초과|미만))";
@@ -237,10 +239,13 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string FromToRegex = @"(으?로?부터|과|에서).+(까지).+";
       public const string AmbiguousRangeModifierPrefix = @"(从|自)";
       public const string ReferenceDatePeriodRegex = @"^[.]";
+      public const string UnspecificDatePeriodRegex = @"^[.]";
       public const string ParserConfigurationBefore = @"((?<include>和|或|及)?(之前|以前)|前)";
       public const string ParserConfigurationAfter = @"((?<include>和|或|及)?(之后|之後|以后|以後)|后|後)";
       public const string ParserConfigurationUntil = @"(直到|直至|截至|截止(到)?)";
       public const string ParserConfigurationSincePrefix = @"(自从|自|自打|打|从)";
+      public const string ParserConfigurationAroundPrefix = @"^[.]";
+      public const string ParserConfigurationAroundSuffix = @"^[.]";
       public const string ParserConfigurationSinceSuffix = @"(以来|开始|起)";
       public const string ParserConfigurationLastWeekDayRegex = @"最后一个";
       public const string ParserConfigurationNextMonthRegex = @"下一个";
@@ -328,6 +333,10 @@ namespace Microsoft.Recognizers.Definitions.Korean
         {
             @"금년",
             @"올해"
+        };
+      public static readonly IList<string> YearToDateTerms = new List<string>
+        {
+            @"올해 초부터 현재까지"
         };
       public static readonly IList<string> LastYearTerms = new List<string>
         {
@@ -680,6 +689,18 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string DateTimePeriodAFRegex = @"(下午|午后|傍晚)";
       public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚)";
       public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜)";
+      public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityDateTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"^[.]", @"^[.]" }
+        };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"早", @"(?<!今|明|日|号)早(?!上)" },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Chinese;
 using DateObject = System.DateTime;
@@ -45,6 +46,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex WeekDayStartEnd = new Regex(DateTimeDefinitions.WeekDayStartEnd, RegexFlags);
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
 
         public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
@@ -130,5 +133,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         Regex ICJKDateExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateExtractorConfiguration.WeekDayStartEnd => WeekDayStartEnd;
+
+        Regex ICJKDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex ZeroToNineIntegerRegexCJK = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexCJK, RegexFlags);
         public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+        public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
         public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
 
@@ -69,6 +70,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         Regex ICJKDateTimeExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateTimeExtractorConfiguration.ConnectorRegex => ConnectorRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateTimeFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateTimeFiltersDict);
 
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+
         public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
+        public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+
+        public static readonly Regex BeforeAfterRegex = new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -104,7 +108,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
 
+        Regex ICJKDateTimePeriodExtractorConfiguration.AmPmDescRegex => AmPmDescRegex;
+
         Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
+        public static readonly Regex AnUnitRegex = new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+
         public static readonly Regex DurationConnectorRegex = new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex AllRegex = new Regex(DateTimeDefinitions.DurationAllRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class ChineseMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, ICJKMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
+        public static readonly Regex UnspecificDatePeriodRegex = new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
         public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex AroundPrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundPrefix, RegexFlags);
+        public static readonly Regex AroundSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundSuffix, RegexFlags);
         public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
         public static readonly Regex PotentialAmbiguousRangeRegex = new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
         public static readonly Regex AmbiguousRangeModifierPrefix = new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
@@ -63,9 +66,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         Regex ICJKMergedExtractorConfiguration.BeforeRegex => BeforeRegex;
 
+        Regex ICJKMergedExtractorConfiguration.UnspecificDatePeriodRegex => UnspecificDatePeriodRegex;
+
         Regex ICJKMergedExtractorConfiguration.SincePrefixRegex => SincePrefixRegex;
 
         Regex ICJKMergedExtractorConfiguration.SinceSuffixRegex => SinceSuffixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundPrefixRegex => AroundPrefixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundSuffixRegex => AroundSuffixRegex;
 
         Regex ICJKMergedExtractorConfiguration.UntilRegex => UntilRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
@@ -76,8 +77,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 },
             };
             Regexes = regexes.ToImmutableDictionary();
+            AmbiguityTimeFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimeFiltersDict);
         }
 
         public ImmutableDictionary<Regex, TimeType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimeFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
@@ -57,5 +58,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         public ImmutableDictionary<Regex, PeriodType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimePeriodFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimePeriodFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             FutureRegex = ChineseDatePeriodExtractorConfiguration.FutureRegex;
             WeekWithWeekDayRangeRegex = ChineseDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
             UnitRegex = ChineseDatePeriodExtractorConfiguration.UnitRegex;
+            DurationUnitRegex = ChineseDatePeriodExtractorConfiguration.DurationUnitRegex;
             WeekOfMonthRegex = ChineseDatePeriodExtractorConfiguration.WeekOfMonthRegex;
             WeekOfYearRegex = ChineseDatePeriodExtractorConfiguration.WeekOfYearRegex;
             WeekOfDateRegex = ChineseDatePeriodExtractorConfiguration.WeekOfDateRegex;
@@ -166,6 +167,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public Regex UnitRegex { get; }
 
+        public Regex DurationUnitRegex { get; }
+
         public Regex WeekOfMonthRegex { get; }
 
         public Regex WeekOfYearRegex { get; }
@@ -241,6 +244,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.ThisYearTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
+        }
+
+        public bool IsYearToDate(string text)
+        {
+            var trimmedText = text.Trim();
+            return DateTimeDefinitions.YearToDateTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
         }
 
         public bool IsLastYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             TimePeriodLeftRegex = ChineseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = ChineseDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = ChineseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
+            AmPmDescRegex = ChineseDateTimePeriodExtractorConfiguration.AmPmDescRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -111,6 +112,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex UnitRegex { get; }
 
         public Regex RestOfDateRegex { get; }
+
+        public Regex AmPmDescRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             LastRegex = ChineseDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = ChineseDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = ChineseDateTimePeriodExtractorConfiguration.FutureRegex;
+            WeekDayRegex = ChineseDateTimePeriodExtractorConfiguration.WeekDayRegex;
             TimePeriodLeftRegex = ChineseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = ChineseDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = ChineseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
@@ -106,6 +107,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex PastRegex { get; }
 
         public Regex FutureRegex { get; }
+
+        public Regex WeekDayRegex { get; }
 
         public Regex TimePeriodLeftRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             SomeRegex = ChineseDurationExtractorConfiguration.SomeRegex;
             MoreOrLessRegex = ChineseDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = ChineseDurationExtractorConfiguration.DurationUnitRegex;
+            AnUnitRegex = ChineseDurationExtractorConfiguration.AnUnitRegex;
             DurationConnectorRegex = ChineseDurationExtractorConfiguration.DurationConnectorRegex;
 
             UnitMap = config.UnitMap;
@@ -42,6 +43,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
+
+        public Regex AnUnitRegex { get; }
 
         public Regex DurationConnectorRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedParserConfiguration.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             AfterRegex = ChineseMergedExtractorConfiguration.AfterRegex;
             SincePrefixRegex = ChineseMergedExtractorConfiguration.SincePrefixRegex;
             SinceSuffixRegex = ChineseMergedExtractorConfiguration.SinceSuffixRegex;
+            AroundPrefixRegex = ChineseMergedExtractorConfiguration.AroundPrefixRegex;
+            AroundSuffixRegex = ChineseMergedExtractorConfiguration.AroundSuffixRegex;
             EqualRegex = ChineseMergedExtractorConfiguration.EqualRegex;
             UntilRegex = ChineseMergedExtractorConfiguration.UntilRegex;
         }
@@ -29,6 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex SincePrefixRegex { get; }
 
         public Regex SinceSuffixRegex { get; }
+
+        public Regex AroundPrefixRegex { get; }
+
+        public Regex AroundSuffixRegex { get; }
 
         public Regex UntilRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -191,6 +191,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string FirstTwoYearGroupName = "firsttwoyearnum";
         public const string LastTwoYearGroupName = "lasttwoyearnum";
         public const string DayGroupName = "day";
+        public const string WeekdayGroupName = "weekday";
         public const string WeekGroupName = "week";
         public const string MonthGroupName = "month";
         public const string RelMonthGroupName = "relmonth";
@@ -200,10 +201,13 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string DecadeGroupName = "decade";
         public const string CenturyGroupName = "century";
         public const string RelCenturyGroupName = "relcentury";
+        public const string AnotherGroupName = "another";
         public const string HalfGroupName = "half";
         public const string HalfTagGroupName = "halfTag";
         public const string FirstHalfGroupName = "firstHalf";
         public const string SecondHalfGroupName = "secondHalf";
+        public const string QuarterGroupName = "quarter";
+        public const string ThreeQuarterGroupName = "threequarter";
         public const string CardinalGroupName = "cardinal";
         public const string TimeOfDayGroupName = "timeOfDay";
         public const string BusinessDayGroupName = "business";
@@ -227,6 +231,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string FewGroupName = "few";
         public const string LaterGroupName = "later";
         public const string SpecificEndOfGroupName = "SpecificEndOf";
+        public const string TomorrowGroupName = "tomorrow";
         public const string LatePrefixGroupName = "LatePrefix";
         public const string MidPrefixGroupName = "MidPrefix";
         public const string RestOfGroupName = "restof";
@@ -267,6 +272,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string TimexNow = "PRESENT_REF";
         public const char TimexFuzzy = 'X';
         public const string TimexFuzzyYear = "XXXX";
+        public const string TimexFuzzyTwoDigitYear = "XX";
         public const string TimexFuzzyMonth = "XX";
         public const string TimexFuzzyWeek = "WXX";
         public const string TimexFuzzyDay = "XX";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -11,6 +11,7 @@ using Microsoft.Recognizers.Text.DateTime.French;
 using Microsoft.Recognizers.Text.DateTime.German;
 using Microsoft.Recognizers.Text.DateTime.Hindi;
 using Microsoft.Recognizers.Text.DateTime.Italian;
+using Microsoft.Recognizers.Text.DateTime.Japanese;
 using Microsoft.Recognizers.Text.DateTime.Korean;
 using Microsoft.Recognizers.Text.DateTime.Portuguese;
 using Microsoft.Recognizers.Text.DateTime.Spanish;
@@ -160,12 +161,13 @@ namespace Microsoft.Recognizers.Text.DateTime
             //        new BaseMergedDateTimeExtractor(
             //            new SwedishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Swedish, options)))));
 
-            // TODO to be uncommented when all tests for Japanese are green.
-            // RegisterModel<DateTimeModel>(
-            //    Culture.Japanese,
-            //    options => new DateTimeModel(
-            //      new FullDateTimeParser(new JapaneseDateTimeParserConfiguration(options)),
-            //      new JapaneseMergedExtractor(options)));
+            RegisterModel<DateTimeModel>(
+                Culture.Japanese,
+                options => new DateTimeModel(
+                  new BaseCJKMergedDateTimeParser(
+                      new JapaneseMergedParserConfiguration(new JapaneseCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Japanese, options)))),
+                  new BaseCJKMergedDateTimeExtractor(
+                      new JapaneseMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Japanese, options)))));
 
             // TODO to be uncommented when all tests for Arabic are green.
             /*RegisterModel<DateTimeModel>(

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDatePeriodExtractor.cs
@@ -91,17 +91,29 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // handle cases with 'within' and 'next'
-                var matchWithin = config.FutureRegex.Match(afterStr);
-                var matchNext = config.FutureRegex.Match(beforeStr);
+                var matchWithin = config.FutureRegex.MatchBegin(afterStr, trim: true);
+                var matchNext = config.FutureRegex.MatchEnd(beforeStr, trim: true);
 
-                if (matchWithin.Success && matchNext.Success)
+                if (matchWithin.Success && matchNext.Success && !matchNext.Groups[Constants.WithinGroupName].Success)
                 {
-                    ret.Add(new Token(duration.Start - matchNext.Value.Length, duration.End + matchWithin.Value.Length));
+                    if (matchNext.Value == matchWithin.Value)
+                    {
+                        ret.Add(new Token(duration.Start - matchNext.Value.Length, duration.End));
+                    }
+                    else
+                    {
+                        ret.Add(new Token(duration.Start - matchNext.Value.Length, duration.End + matchWithin.Value.Length));
+                    }
                 }
                 else if (matchWithin.Success)
                 {
                     ret.Add(new Token(duration.Start, duration.End + matchWithin.Value.Length));
                 }
+                else if (matchNext.Success)
+                {
+                    ret.Add(new Token(duration.Start - matchNext.Value.Length, duration.End));
+                }
+
             }
 
             return ret;
@@ -268,7 +280,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var middleBegin = extractionResults[idx].Start + extractionResults[idx].Length ?? 0;
                 var middleEnd = extractionResults[idx + 1].Start ?? 0;
-                if (middleBegin >= middleEnd)
+                if (middleBegin > middleEnd)
                 {
                     idx++;
                     continue;
@@ -276,9 +288,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
                 var endPointStr = extractionResults[idx + 1].Text;
+                var startPointStr = extractionResults[idx].Text;
 
                 if (config.TillRegex.IsExactMatch(middleStr, trim: true) || (string.IsNullOrEmpty(middleStr) &&
-                    config.TillRegex.MatchBegin(endPointStr, trim: true).Success))
+                    (config.TillRegex.MatchBegin(endPointStr, trim: true).Success || config.TillRegex.MatchEnd(startPointStr, trim: true).Success)))
                 {
                     var periodBegin = extractionResults[idx].Start ?? 0;
                     var periodEnd = (extractionResults[idx + 1].Start ?? 0) + (extractionResults[idx + 1].Length ?? 0);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimeExtractor.cs
@@ -30,12 +30,19 @@ namespace Microsoft.Recognizers.Text.DateTime
         public List<ExtractResult> Extract(string text, DateObject referenceTime)
         {
             var tokens = new List<Token>();
+            var result = new List<ExtractResult>();
+
             tokens.AddRange(MergeDateAndTime(text, referenceTime));
             tokens.AddRange(BasicRegexMatch(text));
             tokens.AddRange(TimeOfToday(text, referenceTime));
             tokens.AddRange(DurationWithAgoAndLater(text, referenceTime));
 
-            return Token.MergeAllTokens(tokens, text, ExtractorName);
+            result = Token.MergeAllTokens(tokens, text, ExtractorName);
+
+            result = ExtractResultExtension.FilterAmbiguity(result, text, this.config.AmbiguityDateTimeFiltersDict);
+
+            return result;
+
         }
 
         // Match now

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimeExtractor.cs
@@ -179,14 +179,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (pos < text.Length)
                 {
                     var suffix = text.Substring(pos);
-                    var beforeMatch = this.config.BeforeRegex.Match(suffix);
-                    var afterMatch = this.config.AfterRegex.Match(suffix);
+                    var match = this.config.BeforeRegex.Match(suffix);
+                    if (!match.Success)
+                    {
+                        match = this.config.AfterRegex.Match(suffix);
+                    }
 
-                    if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value, StringComparison.Ordinal)) ||
-                        (afterMatch.Success && suffix.StartsWith(afterMatch.Value, StringComparison.Ordinal)))
+                    if (match.Success && suffix.StartsWith(match.Value, StringComparison.Ordinal))
                     {
                         var metadata = new Metadata() { IsDurationWithAgoAndLater = true };
-                        ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
+                        ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + match.Length, metadata));
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDateTimePeriodExtractor.cs
@@ -164,6 +164,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         periodBegin = index;
                     }
+                    else
+                    {
+                        var afterStr = text.Substring(periodEnd);
+                        if (this.config.GetFromTokenIndex(afterStr, out index))
+                        {
+                            periodEnd += index;
+                        }
+                    }
 
                     ret.Add(new Token(periodBegin, periodEnd));
                     idx += 2;
@@ -272,7 +280,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
 
-                    if (middleStr.Length != Constants.INVALID_CONNECTOR_CODE)
+                    if (this.config.BeforeAfterRegex.IsMatch(middleStr))
                     {
                         var begin = ers[i].Start ?? 0;
                         var end = (ers[j].Start ?? 0) + (ers[j].Length ?? 0);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDurationExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKDurationExtractor.cs
@@ -55,30 +55,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 res = MergeMultipleDuration(source, res);
             }
 
-            res = FilterAmbiguity(res, source);
+            res = ExtractResultExtension.FilterAmbiguity(res, source, this.config.AmbiguityDurationFiltersDict);
 
             return res;
-        }
-
-        private List<ExtractResult> FilterAmbiguity(List<ExtractResult> extractResults, string text)
-        {
-            if (this.config.AmbiguityDurationFiltersDict != null)
-            {
-                foreach (var regex in this.config.AmbiguityDurationFiltersDict)
-                {
-                    foreach (var extractResult in extractResults)
-                    {
-                        if (regex.Key.IsMatch(text))
-                        {
-                            var matches = regex.Value.Matches(text).Cast<Match>();
-                            extractResults = extractResults.Where(er => !matches.Any(m => m.Index < er.Start + er.Length && m.Index + m.Length > er.Start))
-                                .ToList();
-                        }
-                    }
-                }
-            }
-
-            return extractResults;
         }
 
         private List<ExtractResult> MergeMultipleDuration(string text, List<ExtractResult> extractorResults)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKMergedDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKMergedDateTimeExtractor.cs
@@ -39,9 +39,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             AddTo(ret, this.config.SetExtractor.Extract(text, referenceTime));
             AddTo(ret, this.config.HolidayExtractor.Extract(text, referenceTime));
 
+            ret = FilterUnspecificDatePeriod(ret);
+
             ret = ExtractResultExtension.FilterAmbiguity(ret, text, this.config.AmbiguityFiltersDict);
 
-            AddMod(ret, text);
+            ret = AddMod(ret, text);
 
             ret = ret.OrderBy(p => p.Start).ToList();
 
@@ -65,7 +67,13 @@ namespace Microsoft.Recognizers.Text.DateTime
             return tempDst;
         }
 
-        private void AddMod(List<ExtractResult> ers, string text)
+        private List<ExtractResult> FilterUnspecificDatePeriod(List<ExtractResult> ers)
+        {
+            ers.RemoveAll(o => this.config.UnspecificDatePeriodRegex.IsMatch(o.Text));
+            return ers;
+        }
+
+        private List<ExtractResult> AddMod(List<ExtractResult> ers, string text)
         {
             var lastEnd = 0;
             foreach (var er in ers)
@@ -140,6 +148,28 @@ namespace Microsoft.Recognizers.Text.DateTime
                     er.Metadata = AssignModMetadata(er.Metadata);
                 }
 
+                match = this.config.AroundPrefixRegex.MatchEnd(beforeStr, trim: true);
+
+                if (match.Success && AmbiguousRangeChecker(beforeStr, text, er))
+                {
+                    var modLength = beforeStr.Length - match.Index;
+                    er.Length += modLength;
+                    er.Start -= modLength;
+                    er.Text = text.Substring(er.Start ?? 0, er.Length ?? 0);
+
+                    er.Metadata = AssignModMetadata(er.Metadata);
+                }
+
+                match = this.config.AroundSuffixRegex.MatchBegin(afterStr, trim: true);
+                if (match.Success)
+                {
+                    var modLength = match.Index + match.Length;
+                    er.Length += modLength;
+                    er.Text = text.Substring(er.Start ?? 0, er.Length ?? 0);
+
+                    er.Metadata = AssignModMetadata(er.Metadata);
+                }
+
                 match = this.config.EqualRegex.MatchBegin(beforeStr, trim: true);
                 if (match.Success)
                 {
@@ -151,6 +181,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                     er.Metadata = AssignModMetadata(er.Metadata);
                 }
             }
+
+            return ers;
         }
 
         private void AddTo(List<ExtractResult> dst, List<ExtractResult> src)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKTimeExtractor.cs
@@ -111,6 +111,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
+            result = ExtractResultExtension.FilterAmbiguity(result, source, this.config.AmbiguityTimeFiltersDict);
+
             return result;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/BaseCJKTimePeriodExtractor.cs
@@ -99,6 +99,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
+            // Remove common ambiguous cases
+            result = ExtractResultExtension.FilterAmbiguity(result, source, this.config.AmbiguityTimePeriodFiltersDict);
+
             return result;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateExtractorConfiguration.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex WeekDayStartEnd { get; }
 
+        Regex RangeConnectorSymbolRegex { get; }
+
         IDateTimeExtractor DurationExtractor { get; }
+
+        Dictionary<Regex, Regex> AmbiguityDateFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimeExtractorConfiguration.cs
@@ -30,5 +30,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         IDateTimeExtractor DatePointExtractor { get; }
 
         IDateTimeExtractor TimePointExtractor { get; }
+
+        Dictionary<Regex, Regex> AmbiguityDateTimeFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimePeriodExtractorConfiguration.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex RestOfDateRegex { get; }
 
+        Regex AmPmDescRegex { get; }
+
         Regex ThisRegex { get; }
+
+        Regex BeforeAfterRegex { get; }
 
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKMergedExtractorConfiguration.cs
@@ -32,9 +32,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex BeforeRegex { get; }
 
+        Regex UnspecificDatePeriodRegex { get; }
+
         Regex SinceSuffixRegex { get; }
 
         Regex SincePrefixRegex { get; }
+
+        Regex AroundSuffixRegex { get; }
+
+        Regex AroundPrefixRegex { get; }
 
         Regex UntilRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKTimeExtractorConfiguration.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime
     public interface ICJKTimeExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         ImmutableDictionary<Regex, TimeType> Regexes { get; }
+
+        Dictionary<Regex, Regex> AmbiguityTimeFiltersDict { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKTimePeriodExtractorConfiguration.cs
@@ -10,5 +10,8 @@ namespace Microsoft.Recognizers.Text.DateTime
     public interface ICJKTimePeriodExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         ImmutableDictionary<Regex, PeriodType> Regexes { get; }
+
+        Dictionary<Regex, Regex> AmbiguityTimePeriodFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Japanese;
 using DateObject = System.DateTime;
@@ -42,6 +43,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
+
         public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
         public static readonly Regex DayRegexInCJK = new Regex(DateTimeDefinitions.DateDayRegexInCJK, RegexFlags);
@@ -73,7 +76,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             ImplicitDateList = new List<Regex>
             {
-                LunarRegex, SpecialDayWithNumRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
+                SpecialDayWithNumRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
                 WeekDayRegex, WeekDayOfMonthRegex, SpecialDate, WeekDayAndDayRegex,
             };
 
@@ -134,5 +137,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         Regex ICJKDateExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateExtractorConfiguration.WeekDayStartEnd => WeekDayStartEnd;
+
+        Regex ICJKDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             // ２０１６年１２月１日
             var dateRegex1 = new Regex(DateTimeDefinitions.DateRegexList1, RegexFlags);
 
-            // # ２０１６年１２月 (this is not a Date)
-            // var dateRegex2 = new Regex(DateTimeDefinitions.DateRegexList2, RegexFlags);
+            // 金曜日 6月 15日
+            var dateRegex2 = new Regex(DateTimeDefinitions.DateRegexList2, RegexFlags);
 
             // (2015年)?(农历)?十月二十(星期三)?
             var dateRegex3 = new Regex(DateTimeDefinitions.DateRegexList3, RegexFlags);
@@ -116,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             // Regex precedence where the order between D and M varies is controlled by DefaultLanguageFallback
             var enableDmy = DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY;
 
-            DateRegexList = new List<Regex> { dateRegex1, dateRegex10, /*dateRegex2, */dateRegex9, dateRegex3, dateRegex4, dateRegex5 };
+            DateRegexList = new List<Regex> { dateRegex1, dateRegex10, dateRegex2, dateRegex9, dateRegex3, dateRegex4, dateRegex5 };
             DateRegexList = DateRegexList.Concat(
                 enableDmy ?
                 new[] { dateRegex7, dateRegex6, dateRegex8/*, dateRegex11*/ } :

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public static readonly Regex ZeroToNineIntegerRegexCJK = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexCJK, RegexFlags);
         public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+        public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
         public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
-        public static readonly Regex DynastyDatePeriodRegex = new Regex(DateTimeDefinitions.DynastyDatePeriodRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -141,9 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             DecadeRegex,
             CenturyRegex,
             ReferenceDatePeriodRegex,
-            ComplexDatePeriodRegex,
             DatePointWithAgoAndLater,
-            DynastyDatePeriodRegex,
         };
 
         public JapaneseDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
 
@@ -69,6 +70,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         Regex ICJKDateTimeExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateTimeExtractorConfiguration.ConnectorRegex => ConnectorRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateTimeFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateTimeFiltersDict);
 
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+
         public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Japanese;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.Config;
 using Microsoft.Recognizers.Text.Number.Japanese;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
@@ -18,6 +19,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
 
         public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.DateTimePeriodTillRegex, RegexFlags);
+
+        public static readonly Regex FromPrefixRegex = new Regex(DateTimeDefinitions.DateTimePeriodFromPrefixRegex, RegexFlags);
+
+        public static readonly Regex FromSuffixRegex = new Regex(DateTimeDefinitions.DateTimePeriodFromSuffixRegex, RegexFlags);
+
+        public static readonly Regex ConnectorRegex = new Regex(DateTimeDefinitions.DateTimePeriodConnectorRegex, RegexFlags);
 
         public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.DateTimePeriodPrepositionRegex, RegexFlags);
 
@@ -41,6 +48,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
+        public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+
+        public static readonly Regex BeforeAfterRegex = new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -61,7 +72,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
 
-            CardinalExtractor = new CardinalExtractor(numConfig);
+            CardinalExtractor = new CardinalExtractor(numConfig, CJKNumberExtractorMode.ExtractAll);
 
             SingleDateExtractor = new BaseCJKDateExtractor(new JapaneseDateExtractorConfiguration(this));
             SingleTimeExtractor = new BaseCJKTimeExtractor(new JapaneseTimeExtractorConfiguration(this));
@@ -104,17 +115,30 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
 
+        Regex ICJKDateTimePeriodExtractorConfiguration.AmPmDescRegex => AmPmDescRegex;
+
         Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
 
-            // @TODO move hardcoded values to resources file
-            if (text.Trim().EndsWith("从", StringComparison.Ordinal))
+            var match = FromPrefixRegex.MatchEnd(text, trim: true);
+            if (match.Success)
             {
-                index = text.LastIndexOf("从", StringComparison.Ordinal);
+                index = match.Index;
                 return true;
+            }
+            else
+            {
+                match = FromSuffixRegex.MatchBegin(text, trim: true);
+                if (match.Success)
+                {
+                    index = match.Index + match.Length;
+                    return true;
+                }
             }
 
             return false;
@@ -135,10 +159,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public bool HasConnectorToken(string text)
         {
-            // @TODO move hardcoded values to resources file
-            return text.Equals("和", StringComparison.Ordinal) ||
-                    text.Equals("与", StringComparison.Ordinal) ||
-                    text.Equals("到", StringComparison.Ordinal);
+            return ConnectorRegex.IsExactMatch(text, trim: true);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
+        public static readonly Regex AnUnitRegex = new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+
         public static readonly Regex DurationConnectorRegex = new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex AllRegex = new Regex(DateTimeDefinitions.DurationAllRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     public class JapaneseMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, ICJKMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
+        public static readonly Regex UnspecificDatePeriodRegex = new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
         public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex AroundPrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundPrefix, RegexFlags);
+        public static readonly Regex AroundSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundSuffix, RegexFlags);
         public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
         public static readonly Regex PotentialAmbiguousRangeRegex = new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
         public static readonly Regex AmbiguousRangeModifierPrefix = new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
@@ -63,9 +66,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         Regex ICJKMergedExtractorConfiguration.BeforeRegex => BeforeRegex;
 
+        Regex ICJKMergedExtractorConfiguration.UnspecificDatePeriodRegex => UnspecificDatePeriodRegex;
+
         Regex ICJKMergedExtractorConfiguration.SincePrefixRegex => SincePrefixRegex;
 
         Regex ICJKMergedExtractorConfiguration.SinceSuffixRegex => SinceSuffixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundPrefixRegex => AroundPrefixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundSuffixRegex => AroundSuffixRegex;
 
         Regex ICJKMergedExtractorConfiguration.UntilRegex => UntilRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
@@ -76,8 +77,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 },
             };
             Regexes = regexes.ToImmutableDictionary();
+            AmbiguityTimeFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimeFiltersDict);
+
         }
 
         public ImmutableDictionary<Regex, TimeType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimeFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
@@ -57,5 +58,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         }
 
         public ImmutableDictionary<Regex, PeriodType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimePeriodFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimePeriodFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             FutureRegex = JapaneseDatePeriodExtractorConfiguration.FutureRegex;
             WeekWithWeekDayRangeRegex = JapaneseDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
             UnitRegex = JapaneseDatePeriodExtractorConfiguration.UnitRegex;
+            DurationUnitRegex = JapaneseDatePeriodExtractorConfiguration.DurationUnitRegex;
             WeekOfMonthRegex = JapaneseDatePeriodExtractorConfiguration.WeekOfMonthRegex;
             WeekOfYearRegex = JapaneseDatePeriodExtractorConfiguration.WeekOfYearRegex;
             WeekOfDateRegex = JapaneseDatePeriodExtractorConfiguration.WeekOfDateRegex;
@@ -181,6 +182,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public Regex UnitRegex { get; }
 
+        public Regex DurationUnitRegex { get; }
+
         public Regex WeekOfMonthRegex { get; }
 
         public Regex WeekOfYearRegex { get; }
@@ -247,13 +250,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
-            return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal));
+            return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal) || trimmedText.StartsWith(o, StringComparison.Ordinal));
         }
 
         public bool IsThisYear(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.ThisYearTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
+        }
+
+        public bool IsYearToDate(string text)
+        {
+            var trimmedText = text.Trim();
+            return DateTimeDefinitions.YearToDateTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
         }
 
         public bool IsLastYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Japanese;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.Config;
 using Microsoft.Recognizers.Text.Number.Japanese;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
@@ -43,7 +44,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
 
-            CardinalExtractor = config.CardinalExtractor;
+            CardinalExtractor = new CardinalExtractor(numConfig, CJKNumberExtractorMode.ExtractAll);
             CardinalParser = AgnosticNumberParserFactory.GetParser(
                 AgnosticNumberParserType.Cardinal, new JapaneseNumberParserConfiguration(numConfig));
 
@@ -67,6 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             TimePeriodLeftRegex = JapaneseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = JapaneseDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = JapaneseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
+            AmPmDescRegex = JapaneseDateTimePeriodExtractorConfiguration.AmPmDescRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -111,6 +113,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public Regex UnitRegex { get; }
 
         public Regex RestOfDateRegex { get; }
+
+        public Regex AmPmDescRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             LastRegex = JapaneseDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = JapaneseDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = JapaneseDateTimePeriodExtractorConfiguration.FutureRegex;
+            WeekDayRegex = JapaneseDateTimePeriodExtractorConfiguration.WeekDayRegex;
             TimePeriodLeftRegex = JapaneseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = JapaneseDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = JapaneseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
@@ -107,6 +108,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public Regex PastRegex { get; }
 
         public Regex FutureRegex { get; }
+
+        public Regex WeekDayRegex { get; }
 
         public Regex TimePeriodLeftRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             SomeRegex = JapaneseDurationExtractorConfiguration.SomeRegex;
             MoreOrLessRegex = JapaneseDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = JapaneseDurationExtractorConfiguration.DurationUnitRegex;
+            AnUnitRegex = JapaneseDurationExtractorConfiguration.AnUnitRegex;
             DurationConnectorRegex = JapaneseDurationExtractorConfiguration.DurationConnectorRegex;
 
             UnitMap = config.UnitMap;
@@ -42,6 +43,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
+
+        public Regex AnUnitRegex { get; }
 
         public Regex DurationConnectorRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             { "旧正月", NewYear },
             { "元旦节", NewYear },
             { "お正月", NewYear },
+            { "独立記念日", UsaIndependenceDay },
             { "旧暦の正月初一", SpringDay },
             { "教师节", TeacherDay },
             { "教師の日", TeacherDay },
@@ -149,6 +150,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         }
 
         private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
+
+        private static DateObject UsaIndependenceDay(int year) => new DateObject(year, 7, 4);
 
         private static DateObject TeacherDay(int year) => new DateObject(year, 9, 10);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedParserConfiguration.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             AfterRegex = JapaneseMergedExtractorConfiguration.AfterRegex;
             SincePrefixRegex = JapaneseMergedExtractorConfiguration.SincePrefixRegex;
             SinceSuffixRegex = JapaneseMergedExtractorConfiguration.SinceSuffixRegex;
+            AroundPrefixRegex = JapaneseMergedExtractorConfiguration.AroundPrefixRegex;
+            AroundSuffixRegex = JapaneseMergedExtractorConfiguration.AroundSuffixRegex;
             EqualRegex = JapaneseMergedExtractorConfiguration.EqualRegex;
             UntilRegex = JapaneseMergedExtractorConfiguration.UntilRegex;
         }
@@ -29,6 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public Regex SincePrefixRegex { get; }
 
         public Regex SinceSuffixRegex { get; }
+
+        public Regex AroundPrefixRegex { get; }
+
+        public Regex AroundSuffixRegex { get; }
 
         public Regex UntilRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateExtractorConfiguration.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Korean;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Korean;
 using DateObject = System.DateTime;
@@ -47,6 +48,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public static readonly Regex WeekDayStartEnd = new Regex(DateTimeDefinitions.WeekDayStartEnd, RegexFlags);
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
 
         public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
@@ -134,5 +137,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         Regex ICJKDateExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateExtractorConfiguration.WeekDayStartEnd => WeekDayStartEnd;
+
+        Regex ICJKDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDatePeriodExtractorConfiguration.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public static readonly Regex ZeroToNineIntegerRegexCJK = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexCJK, RegexFlags);
         public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+        public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
         public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Korean;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
 
@@ -69,6 +70,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         Regex ICJKDateTimeExtractorConfiguration.AfterRegex => AfterRegex;
 
         Regex ICJKDateTimeExtractorConfiguration.ConnectorRegex => ConnectorRegex;
+
+        public Dictionary<Regex, Regex> AmbiguityDateTimeFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityDateTimeFiltersDict);
 
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+
         public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
+        public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+
+        public static readonly Regex BeforeAfterRegex = new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -104,7 +108,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
 
+        Regex ICJKDateTimePeriodExtractorConfiguration.AmPmDescRegex => AmPmDescRegex;
+
         Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDurationExtractorConfiguration.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
+        public static readonly Regex AnUnitRegex = new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+
         public static readonly Regex DurationConnectorRegex = new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex AllRegex = new Regex(DateTimeDefinitions.DurationAllRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanMergedExtractorConfiguration.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
     public class KoreanMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, ICJKMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
+        public static readonly Regex UnspecificDatePeriodRegex = new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
         public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex AroundPrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundPrefix, RegexFlags);
+        public static readonly Regex AroundSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationAroundSuffix, RegexFlags);
         public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
         public static readonly Regex PotentialAmbiguousRangeRegex = new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
         public static readonly Regex AmbiguousRangeModifierPrefix = new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
@@ -63,9 +66,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         Regex ICJKMergedExtractorConfiguration.BeforeRegex => BeforeRegex;
 
+        Regex ICJKMergedExtractorConfiguration.UnspecificDatePeriodRegex => UnspecificDatePeriodRegex;
+
         Regex ICJKMergedExtractorConfiguration.SincePrefixRegex => SincePrefixRegex;
 
         Regex ICJKMergedExtractorConfiguration.SinceSuffixRegex => SinceSuffixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundPrefixRegex => AroundPrefixRegex;
+
+        Regex ICJKMergedExtractorConfiguration.AroundSuffixRegex => AroundSuffixRegex;
 
         Regex ICJKMergedExtractorConfiguration.UntilRegex => UntilRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanTimeExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Korean;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Korean
 {
@@ -76,8 +77,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
                 },
             };
             Regexes = regexes.ToImmutableDictionary();
+            AmbiguityTimeFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimeFiltersDict);
         }
 
         public ImmutableDictionary<Regex, TimeType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimeFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanTimePeriodExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Korean;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Korean
 {
@@ -57,5 +58,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         }
 
         public ImmutableDictionary<Regex, PeriodType> Regexes { get; }
+
+        public Dictionary<Regex, Regex> AmbiguityTimePeriodFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimePeriodFiltersDict);
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDatePeriodParserConfiguration.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             FutureRegex = KoreanDatePeriodExtractorConfiguration.FutureRegex;
             WeekWithWeekDayRangeRegex = KoreanDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
             UnitRegex = KoreanDatePeriodExtractorConfiguration.UnitRegex;
+            DurationUnitRegex = KoreanDatePeriodExtractorConfiguration.DurationUnitRegex;
             WeekOfMonthRegex = KoreanDatePeriodExtractorConfiguration.WeekOfMonthRegex;
             WeekOfYearRegex = KoreanDatePeriodExtractorConfiguration.WeekOfYearRegex;
             WeekOfDateRegex = KoreanDatePeriodExtractorConfiguration.WeekOfDateRegex;
@@ -173,6 +174,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public Regex UnitRegex { get; }
 
+        public Regex DurationUnitRegex { get; }
+
         public Regex WeekOfMonthRegex { get; }
 
         public Regex WeekOfYearRegex { get; }
@@ -246,6 +249,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.ThisYearTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
+        }
+
+        public bool IsYearToDate(string text)
+        {
+            var trimmedText = text.Trim();
+            return DateTimeDefinitions.YearToDateTerms.Any(o => trimmedText.Equals(o, StringComparison.Ordinal));
         }
 
         public bool IsLastYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             TimePeriodLeftRegex = KoreanDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = KoreanDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = KoreanDateTimePeriodExtractorConfiguration.RestOfDateRegex;
+            AmPmDescRegex = KoreanDateTimePeriodExtractorConfiguration.AmPmDescRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -111,6 +112,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public Regex UnitRegex { get; }
 
         public Regex RestOfDateRegex { get; }
+
+        public Regex AmPmDescRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             LastRegex = KoreanDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = KoreanDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = KoreanDateTimePeriodExtractorConfiguration.FutureRegex;
+            WeekDayRegex = KoreanDateTimePeriodExtractorConfiguration.WeekDayRegex;
             TimePeriodLeftRegex = KoreanDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = KoreanDateTimePeriodExtractorConfiguration.UnitRegex;
             RestOfDateRegex = KoreanDateTimePeriodExtractorConfiguration.RestOfDateRegex;
@@ -106,6 +107,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public Regex PastRegex { get; }
 
         public Regex FutureRegex { get; }
+
+        public Regex WeekDayRegex { get; }
 
         public Regex TimePeriodLeftRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDurationParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             SomeRegex = KoreanDurationExtractorConfiguration.SomeRegex;
             MoreOrLessRegex = KoreanDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = KoreanDurationExtractorConfiguration.DurationUnitRegex;
+            AnUnitRegex = KoreanDurationExtractorConfiguration.AnUnitRegex;
             DurationConnectorRegex = KoreanDurationExtractorConfiguration.DurationConnectorRegex;
 
             UnitMap = config.UnitMap;
@@ -42,6 +43,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
+
+        public Regex AnUnitRegex { get; }
 
         public Regex DurationConnectorRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanMergedParserConfiguration.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             AfterRegex = KoreanMergedExtractorConfiguration.AfterRegex;
             SincePrefixRegex = KoreanMergedExtractorConfiguration.SincePrefixRegex;
             SinceSuffixRegex = KoreanMergedExtractorConfiguration.SinceSuffixRegex;
+            AroundPrefixRegex = KoreanMergedExtractorConfiguration.AroundPrefixRegex;
+            AroundSuffixRegex = KoreanMergedExtractorConfiguration.AroundSuffixRegex;
             EqualRegex = KoreanMergedExtractorConfiguration.EqualRegex;
             UntilRegex = KoreanMergedExtractorConfiguration.UntilRegex;
         }
@@ -29,6 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public Regex SincePrefixRegex { get; }
 
         public Regex SinceSuffixRegex { get; }
+
+        public Regex AroundPrefixRegex { get; }
+
+        public Regex AroundSuffixRegex { get; }
 
         public Regex UntilRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -2227,7 +2227,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             var trimmedText = text.Trim();
             var match = this.config.DecadeWithCenturyRegex.MatchExact(trimmedText, trim: true);
-            string beginLuisStr, endLuisStr;
 
             if (match.Success)
             {
@@ -2318,23 +2317,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             // swift = 0 corresponding to the/this decade
             var totalLastYear = decadeLastYear * Math.Abs(swift == 0 ? 1 : swift);
 
-            if (inputCentury)
-            {
-                beginLuisStr = DateTimeFormatUtil.LuisDate(beginYear, 1, 1);
-                endLuisStr = DateTimeFormatUtil.LuisDate(beginYear + totalLastYear, 1, 1);
-            }
-            else
-            {
-                var beginYearStr = "XX" + decade;
-                beginLuisStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
-                beginLuisStr = beginLuisStr.Replace("XXXX", beginYearStr);
-
-                var endYearStr = "XX" + ((decade + totalLastYear) % 100).ToString("D2", CultureInfo.InvariantCulture);
-                endLuisStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
-                endLuisStr = endLuisStr.Replace("XXXX", endYearStr);
-            }
-
-            ret.Timex = $"({beginLuisStr},{endLuisStr},P{totalLastYear}Y)";
+            ret.Timex = TimexUtility.GenerateDecadeTimex(beginYear, totalLastYear, decade, inputCentury);
 
             int futureYear = beginYear, pastYear = beginYear;
             var startDate = DateObject.MinValue.SafeCreateFromValue(beginYear, 1, 1);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateParser.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (!string.IsNullOrEmpty(monthStr))
                 {
                     hasMonth = true;
+                    hasYear = true;
                     if (this.config.NextRe.Match(monthStr).Success)
                     {
                         month++;
@@ -466,7 +467,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             weekDay = 7;
                         }
 
-                        ret.Timex = DateTimeFormatUtil.LuisDate(pastDate);
+                        ret.Timex = TimexUtility.GenerateWeekdayTimex(weekDay);
                     }
                 }
 
@@ -539,7 +540,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (match.Success)
             {
-                var weekdayKey = match.Groups["weekday"].Value;
+                var weekdayKey = match.Groups[Constants.WeekdayGroupName].Value;
                 var weekday = this.config.DayOfWeek[weekdayKey];
                 var value = reference.This((DayOfWeek)weekday);
 
@@ -553,7 +554,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     value = reference.Next((DayOfWeek)weekday);
                 }
 
-                result.Timex = "XXXX-WXX-" + weekday;
+                result.Timex = TimexUtility.GenerateWeekdayTimex(weekday);
                 var futureDate = value;
                 var pastDate = value;
                 if (futureDate < reference)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateTimeParser.cs
@@ -220,7 +220,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (eod.Success && ers.Count != 1)
             {
-                ret = DateTimeFormatUtil.ResolveEndOfDay(DateTimeFormatUtil.FormatDate(referenceTime), referenceTime, referenceTime);
+                if (eod.Groups[Constants.TomorrowGroupName].Success)
+                {
+                    ret = DateTimeFormatUtil.ResolveEndOfDay(DateTimeFormatUtil.FormatDate(referenceTime.AddDays(1)), referenceTime.AddDays(1), referenceTime.AddDays(1));
+                }
+                else
+                {
+                    ret = DateTimeFormatUtil.ResolveEndOfDay(DateTimeFormatUtil.FormatDate(referenceTime), referenceTime, referenceTime);
+                }
+
                 return ret;
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateTimePeriodParser.cs
@@ -129,6 +129,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             // handle cases with time like 25時 which resolve to the next day
             var swiftDay = 0;
             var timexHours = TimexUtility.ParseHoursFromTimePeriodTimex(pr2.TimexStr);
+            if (!this.config.AmPmDescRegex.Match(text).Success && timexHours.Item1 < Constants.HalfDayHourCount && timexHours.Item2 < Constants.HalfDayHourCount)
+            {
+                ret.Comment = Constants.Comment_AmPm;
+            }
+
             if (timexHours.Item1 > Constants.DayHourCount)
             {
                 pastDate = pastDate.AddDays(1);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDatePeriodParserConfiguration.cs
@@ -86,6 +86,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex UnitRegex { get; }
 
+        Regex DurationUnitRegex { get; }
+
         Regex WeekOfMonthRegex { get; }
 
         Regex WeekOfYearRegex { get; }
@@ -143,6 +145,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         bool IsYearOnly(string text);
 
         bool IsThisYear(string text);
+
+        bool IsYearToDate(string text);
 
         bool IsLastYear(string text);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex RestOfDateRegex { get; }
 
+        Regex AmPmDescRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         bool GetMatchedTimeRange(string text, out string todSymbol, out int beginHour, out int endHour, out int endMinute);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex FutureRegex { get; }
 
+        Regex WeekDayRegex { get; }
+
         Regex TimePeriodLeftRegex { get; }
 
         Regex UnitRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDurationParserConfiguration.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex DurationUnitRegex { get; }
 
+        Regex AnUnitRegex { get; }
+
         Regex DurationConnectorRegex { get; }
 
         IImmutableDictionary<string, string> UnitMap { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKMergedParserConfiguration.cs
@@ -20,5 +20,9 @@ namespace Microsoft.Recognizers.Text.DateTime
         Regex UntilRegex { get; }
 
         Regex EqualRegex { get; }
+
+        Regex AroundPrefixRegex { get; }
+
+        Regex AroundSuffixRegex { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeFunctions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
                 }
             }
 
-            if (noDesc && hour <= Constants.HalfDayHourCount)
+            if (noDesc && hour <= Constants.HalfDayHourCount && hour > Constants.DayHourStart)
             {
                 // build.Append("ampm");
                 dateTimeResult.Comment = Constants.Comment_AmPm;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -74,19 +74,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             }
 
             // No 'am' or 'pm' indicator
-            if (leftResult.LowBound == -1 && rightResult.LowBound == -1 && leftResult.Hour <= Constants.HalfDayHourCount && rightResult.Hour <= Constants.HalfDayHourCount && spanHour > Constants.HalfDayHourCount)
+            if (leftResult.LowBound == -1 && rightResult.LowBound == -1 && leftResult.Hour <= Constants.HalfDayHourCount && rightResult.Hour <= Constants.HalfDayHourCount)
             {
-                if (leftResult.Hour > rightResult.Hour)
+                if (spanHour > Constants.HalfDayHourCount)
                 {
-                    if (leftResult.Hour == Constants.HalfDayHourCount)
+                    if (leftResult.Hour > rightResult.Hour)
                     {
-                        leftResult.Hour -= Constants.HalfDayHourCount;
-                    }
-                    else
-                    {
-                        rightResult.Hour += Constants.HalfDayHourCount;
+                        if (leftResult.Hour == Constants.HalfDayHourCount)
+                        {
+                            leftResult.Hour -= Constants.HalfDayHourCount;
+                        }
+                        else
+                        {
+                            rightResult.Hour += Constants.HalfDayHourCount;
+                        }
                     }
                 }
+
+                ret.Comment = Constants.Comment_AmPm;
             }
 
             int day = refTime.Day,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -148,6 +148,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
         }
 
+        public static string GenerateWeekdayTimex(int weekday)
+        {
+            return $"{Constants.TimexFuzzyYear}{Constants.DateTimexConnector}{Constants.TimexFuzzyWeek}{Constants.DateTimexConnector}{weekday}";
+        }
+
         public static string GenerateMonthTimex(DateObject date = default(DateObject))
         {
             if (date.IsDefaultValue())

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -204,6 +204,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             return $"({DateTimeFormatUtil.LuisDate(beginDate)},{DateTimeFormatUtil.LuisDate(endDate)},{durationTimex})";
         }
 
+        public static string GenerateDatePeriodTimexWithDuration(DateObject beginDate, DateObject endDate, string durationTimex)
+        {
+            return $"({DateTimeFormatUtil.LuisDate(beginDate)},{DateTimeFormatUtil.LuisDate(endDate)},{durationTimex})";
+        }
+
         public static string GenerateDurationTimex(double number, string unitStr, bool isLessThanDay)
         {
             if (!Constants.TimexBusinessDay.Equals(unitStr, StringComparison.Ordinal))
@@ -442,6 +447,28 @@ namespace Microsoft.Recognizers.Text.DateTime
             return timexEndInclusive;
         }
 
+        public static string GenerateDecadeTimex(int beginYear, int totalLastYear, int decade, bool inputCentury)
+        {
+            string beginStr, endStr;
+            if (inputCentury)
+            {
+                beginStr = DateTimeFormatUtil.LuisDate(beginYear, 1, 1);
+                endStr = DateTimeFormatUtil.LuisDate(beginYear + totalLastYear, 1, 1);
+            }
+            else
+            {
+                var beginYearStr = Constants.TimexFuzzyTwoDigitYear + decade;
+                beginStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
+                beginStr = beginStr.Replace(Constants.TimexFuzzyYear, beginYearStr);
+
+                var endYearStr = Constants.TimexFuzzyTwoDigitYear + ((decade + totalLastYear) % 100).ToString("D2", CultureInfo.InvariantCulture);
+                endStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
+                endStr = endStr.Replace(Constants.TimexFuzzyYear, endYearStr);
+            }
+
+            return $"({beginStr},{endStr},{Constants.GeneralPeriodPrefix}{totalLastYear}{Constants.TimexYear})";
+        }
+
         public static string GenerateWeekOfYearTimex(int year, int weekNum)
         {
             var weekTimex = GenerateWeekTimex(weekNum);
@@ -467,6 +494,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             return dateTimeTimex2.Equals(Constants.TimexNow, StringComparison.Ordinal) ? DateTimeFormatUtil.LuisDateShortTime(dateTime1) :
                     dateTimeTimex2.Split(Constants.TimeTimexPrefix[0])[0] + timeTimex1;
+        }
+
+        public static string GenerateDateTimeTimex(DateObject dateTime)
+        {
+            return DateTimeFormatUtil.LuisDateTime(dateTime);
         }
 
         public static string GenerateDateTimePeriodTimex(string beginTimex, string endTimex, string durationTimex)

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -281,6 +281,8 @@ DateTimePeriodTillRegex: !simpleRegex
   def: (?<till>到|直到|--|-|—|——)
 DateTimePeriodPrepositionRegex: !simpleRegex
   def: (?<prep>^\s*的|在\s*$)
+BeforeAfterRegex: !simpleRegex
+  def: ^\b$
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -295,7 +297,7 @@ DateTimePeriodLastRegex: !simpleRegex
 DateTimePeriodNextRegex: !simpleRegex
   def: 下个|下一个|下|下一
 AmPmDescRegex: !simpleRegex
-  def: (?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))
+  def: (?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m|上午|中午|下午|午后|晚上|夜里|夜晚|夜间|深夜|傍晚|晚|早间?))
 TimeOfDayRegex: !simpleRegex
   def: (?<timeOfDay>凌晨|清晨|早上|早间|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晚)
 SpecificTimeOfDayRegex: !nestedRegex
@@ -364,6 +366,8 @@ DurationAmbiguousUnits: !list
 DurationUnitRegex: !nestedRegex
   def: (?<unit>{DateUnitRegex}|分钟?|秒钟?|个?小时|时|个?钟头|天|个?星期|周|週|个?月|年)
   references: [DateUnitRegex]
+AnUnitRegex: !simpleRegex
+  def: ^[.]
 DurationConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>[多又余零]?)\s*$
 ConnectorRegex: !simpleRegex
@@ -487,6 +491,9 @@ AmbiguousRangeModifierPrefix: !simpleRegex
 ReferenceDatePeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
   def: ^[.]
+UnspecificDatePeriodRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
 ParserConfigurationBefore: !simpleRegex
   def: ((?<include>和|或|及)?(之前|以前)|前)
 ParserConfigurationAfter: !simpleRegex
@@ -497,6 +504,12 @@ ParserConfigurationSincePrefix: !simpleRegex
   def: (自从|自|自打|打|从)
 ParserConfigurationSinceSuffix: !simpleRegex
   def: (以来|开始|起)
+ParserConfigurationAroundPrefix: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
+ParserConfigurationAroundSuffix: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
 ParserConfigurationLastWeekDayRegex: 最后一个
 ParserConfigurationNextMonthRegex: 下一个
 ParserConfigurationLastMonthRegex: 上一个
@@ -566,6 +579,10 @@ ThisYearTerms: !list
   types: [ string ]
   entries:
     - 今年
+YearToDateTerms: !list
+  types: [ string ]
+  entries:
+    - 今年迄今
 LastYearTerms: !list
   types: [ string ]
   entries:
@@ -941,6 +958,18 @@ DateTimePeriodEVRegex: !simpleRegex
   def: (晚上|夜里|夜晚|晚)
 DateTimePeriodNIRegex: !simpleRegex
   def: (半夜|夜间|深夜)
+AmbiguityTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
+AmbiguityDateFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
+AmbiguityDateTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
 # For cases like "12号", singleWord "早" and "晚"
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -962,6 +962,10 @@ AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     '^[.]': '^[.]'
+AmbiguityTimePeriodFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
 AmbiguityDateFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -38,7 +38,7 @@ DateYearInCJKRegex: !nestedRegex
   def: (?<yearCJK>({ZeroToNineIntegerRegexCJK}{2,4}|{DynastyYearRegex}))年?
   references: [ZeroToNineIntegerRegexCJK, DynastyYearRegex]
 WeekDayRegex: !simpleRegex
-  def: (週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)
+  def: (前の?)?(週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)
 WeekDayStartEnd: !nestedRegex
   def: (^(の)?{WeekDayRegex}|{WeekDayRegex}$)
   references: [WeekDayRegex]
@@ -48,7 +48,7 @@ DateThisRegex: !nestedRegex
   def: (这个|这一个|这|这一|本|(?<week>今週)|これ?)(的|の)?({WeekDayRegex}|日)
   references: [WeekDayRegex]
 DateLastRegex: !nestedRegex
-  def: (上一个|上个|上一|上|最后一个|最后|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)
+  def: (上一个|上个|上一|上|最后一个|最后|前の?|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)
   references: [WeekDayRegex]
 DateNextRegex: !nestedRegex
   def: (下一个|下个|下一|下|(?<week>(来|翌)週)|次)(的|の)?{WeekDayRegex}
@@ -93,17 +93,17 @@ DateUnitRegex: !simpleRegex
 BeforeRegex: !simpleRegex
   def: 以前|之前|前|先
 AfterRegex: !simpleRegex
-  def: 過ぎ|以内|以后|以後|之后|之後|后|後|で(?!す)|あと|以降
+  def: 過ぎ|以后|以後|之后|之後|后|後|で(?!す)|あと|以降
 TimePeriodLeftRegex: !simpleRegex
-  def: あと
+  def: (?<LatePrefix>あとで?)|(?<EarlyPrefix>の早い時間)
 DateRegexList1: !nestedRegex
   # ２０１６年１２月１日
   def: ({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,)*{WeekDayRegex})?)
   references: [ MonthRegex, DayRegexForPeriod, SimpleYearRegex, WeekDayRegex, LunarRegex, DateYearInCJKRegex ]
 DateRegexList2: !nestedRegex
-  # ２０１６年１２月
-  def: (({SimpleYearRegex}|{DateYearInCJKRegex}){MonthRegexForPeriod}\s*)
-  references: [ MonthRegexForPeriod, SimpleYearRegex, DateYearInCJKRegex ]
+  # 金曜日 6月 15日
+  def: ((?<!「)今){WeekDayRegex}\s*[/\\\-]?\s*({MonthRegex}\s*[/\\\-]?\s*{DayRegex}|\({MonthRegex}\s*[/\\\-]?\s*{DayRegex}\))
+  references: [ WeekDayRegex, MonthRegex, DayRegex ]
 DateRegexList3: !nestedRegex
   def: ((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?
   references: [MonthRegex, DateDayRegexInCJK, SimpleYearRegex, LunarRegex, WeekDayRegex, DateYearInCJKRegex, DayRegex]
@@ -194,7 +194,7 @@ PureNumYearAndMonth: !nestedRegex
   def: ({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})(?!\d)|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})
   references: [YearRegexInNumber, MonthNumRegex, DateRangePrepositions]
 OneWordPeriodRegex: !nestedRegex
-  def: ({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<!休|建国記念)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?
+  def: ({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<business>営業)日|(?<!休|建国記念|営業)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?
   references: [DateRangePrepositions, MonthRegex, DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex, DayRegex, ZeroToNineIntegerRegexCJK, HalfYearRegex]
 LaterEarlyPeriodRegex: !simpleRegex 
   def: ((?<next>来|翌)|(?<this>今|同じ)|(?<last>この|去|先|前(の)?))?(?<suffix>(?<!建国記念)日(?!付)|(?<week>週(間)?)|(?<month>(正|一|二|三|四|五|六|七|八|九|十|十一|十二|0?[1-9]|1[0-2]))?((?<!((?<![1-9])0))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々|齢)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後|の後半)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>(の)?(半ば|中旬))|(?<EarlyPrefix>(の)?初め|のはじめ|早くに|初旬|(?<RelEarly>ちょっと前に|上旬(に)?)))
@@ -232,7 +232,7 @@ MonthDayRange: !nestedRegex
   def: ({YearNumRegex})?({MonthRegex}|{MonthNumRegex})[/\\\-]?(({DayRegexForPeriod}|{DateDayRegexInCJK})|{WeekDayRegex})から(({DayRegexForPeriod}|{DateDayRegexInCJK})|{WeekDayRegex})(までの間|まで|の間|にわたって)
   references: [YearNumRegex, MonthRegex, MonthNumRegex, DayRegexForPeriod, WeekDayRegex, DateDayRegexInCJK]
 YearToYear: !nestedRegex
-  def: ({DateRangePrepositions})(({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})から({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})(までの間|まで|の間|にわたって))
+  def: ({DateRangePrepositions})(({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})から({SpecialYearRegex}|{DatePeriodYearInCJKRegex}|{YearNumRegex})(ま(での間|で)?|の間|にわたって))
   references: [DateRangePrepositions, YearNumRegex, SpecialYearRegex, DatePeriodYearInCJKRegex]
 YearToYearSuffixRequired: !simpleRegex
   # TODO: modify below regex according to the counterpart in Chinese
@@ -253,7 +253,7 @@ ComplexDatePeriodRegex: !nestedRegex
   def: ({DateRangePrepositions})(?<start>.+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)
   references: [ DateRangePrepositions ]
 PastRegex: !simpleRegex
-  def: (?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)
+  def: (?<before>まで)|(?<past>(この|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)
 FutureRegex: !simpleRegex
   def: (?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これから(の)?|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))
 SeasonRegex: !simpleRegex
@@ -279,7 +279,7 @@ RelativeCenturyRegex: !nestedRegex
 DecadeRegexInCJK: !simpleRegex
   def: (?<decade>十|一十|二十|三十|四十|五十|六十|七十|八十|九十)
 DecadeRegex: !nestedRegex
-  def: ({DateRangePrepositions})(?<centurysuf>({CenturyRegex}|{CenturyRegexInCJK}|{RelativeCenturyRegex}))?の?(?<firsttwoyearnum>\d{2}(?=\d))?(?<decade>((\d{1}0)|{DecadeRegexInCJK}))年代(のごろ)?
+  def: ({DateRangePrepositions})(?<centurysuf>({CenturyRegex}|{CenturyRegexInCJK}|{RelativeCenturyRegex}))?の?(?<century>(?<firsttwoyearnum>\d{2}(?=\d)))?(?<decade>((\d{1}0)|{DecadeRegexInCJK}))年代(のごろ)?
   references: [DateRangePrepositions, CenturyRegex, CenturyRegexInCJK, RelativeCenturyRegex, DecadeRegexInCJK]
 #DateTimeExtractorCJK
 PrepositionRegex: !simpleRegex
@@ -311,7 +311,7 @@ SpecialDayEndOfRegex: !nestedRegex
   def: ((?<SpecificEndOf>明日の終わり|今?({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))
   references: [WeekDayRegex]
 TimeOfSpecialDayRegex: !nestedRegex
-  def: (({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)
+  def: (({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)
   references: [ TomorrowRegex, YesterdayRegex, TodayRegex, WeekDayRegex, SpecialDayEndOfRegex, SpecialDayHourRegex, SpecialDayMinuteRegex, SpecialDaySecondRegex, SpecialDayModRegex, FromNowRegex ]
 NowTimeRegex: !simpleRegex
   def: (现在|今)
@@ -331,7 +331,7 @@ DateTimePeriodConnectorRegex: !simpleRegex
 DateTimePeriodPrepositionRegex: !simpleRegex
   def: (?<prep>^\s*(的|の(?!午)|在)\s*$)
 BeforeAfterRegex: !simpleRegex
-  def: (前|後)
+  def: (?<!午)(前|後)
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -383,14 +383,14 @@ DurationHalfRegex: !simpleRegex
 DurationRelativeDurationUnitRegex: !simpleRegex
   def: (?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|(?<!「)明日)|(?<another>(?<!(に))もう(?=\d)|別)の?(日|週|月)?
 AgoLaterRegex: !simpleRegex
-  def: (?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で)
+  def: (?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で|あと)
 DurationDuringRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^[.]
 DurationSomeRegex: !simpleRegex
   def: (?<few>数(?<unit>((か|ヶ)?(時|月|日(?!都合)|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)
 DurationMoreOrLessRegex: !simpleRegex
-  def: (?<less>たらず)|(?<more>以上)
+  def: (?<less>たらず|以下|を下回る)|(?<more>以上|を上回る)
 DurationYearRegex: !simpleRegex
   def: ((\d{3,4})|0\d|两千)\s*年
 DurationHalfSuffixRegex: !simpleRegex
@@ -401,7 +401,7 @@ DurationSuffixList: !dictionary
     M: 分|分間
     S: 秒钟|秒|秒間
     H: 時|時間
-    D: 天|日|日間
+    D: 天|日|泊|日間
     BD: 営業日
     W: 星期|个星期|周|週間|週
     MON: ひと月|月間|か月間|ヶ月|ヶ月間|个月|か月|月
@@ -416,6 +416,7 @@ DurationAmbiguousUnits: !list
     - 小时
     - 天
     - 日
+    - 泊
     - 星期
     - 个星期
     - 周
@@ -423,8 +424,9 @@ DurationAmbiguousUnits: !list
     - 年
     - 時
     - 時間
+    - 月
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>年|个月|月|周|時間?|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)
+  def: (?<unit>年|个月|月|周|時間?|泊|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以[上下]|たらず|を上回る|を下回る)
   references: [DayNumberRegex]
 AnUnitRegex: !simpleRegex
   def: (?<another>別)の?(?<unit>日|年|月|時間?)
@@ -508,7 +510,7 @@ LessTimeRegex: !nestedRegex
   def: (({TimeHourRegex}|(?<hour>{TimeHourNumRegex}):){LessThanHalfHourRegex}前)({AmPmDescRegex})?
   references: [TimeHourRegex, LessThanHalfHourRegex, TimeHourNumRegex, AmPmDescRegex ]
 TimeDayDescRegex: !nestedRegex
-  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
+  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|(早朝)?午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
   references: [TimeDigitTimeRegex, TimeCJKTimeRegex]
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)
@@ -602,6 +604,7 @@ ParserConfigurationUnitMap: !dictionary
     日間: D
     営業日: BD
     天: D
+    泊: D
     小时: H
     時間: H 
     时: H
@@ -617,6 +620,9 @@ ParserConfigurationUnitMap: !dictionary
     数: some
     たらず: less
     以上: more
+    以下: less
+    を上回る: more
+    を下回る: less
 ParserConfigurationUnitValueMap: !dictionary
   types: [string, long]
   entries:
@@ -1001,6 +1007,7 @@ AmbiguityDateFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     '^今週$': '今週'
+    '^[1一]日$': '[1一]日'
 AmbiguityDateTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
@@ -1013,7 +1020,11 @@ AmbiguityDatePeriodFiltersDict: !dictionary
 AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    '^(\d+|[一二三四五六七八九十廿])時間$': '^(\d+|[一二三四五六七八九十廿])時間'
+    '^(\d+|[一二三四五六七八九十廿])時$': '(\d+|[一二三四五六七八九十廿])時間'
+AmbiguityTimePeriodFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^早$': '早'
 AmbiguityDurationFiltersDict: !dictionary
   types: [ string, string ]
   entries:
@@ -1027,6 +1038,7 @@ AmbiguityDurationFiltersDict: !dictionary
     '週間$': '(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))週間'
     '(日|週|月|年)間?$': '(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?'
     '^(数ヶ|数|前|昨日|以内|後|明日|もう)$': '(数ヶ|数|前|昨日|以内|後|明日|もう)(?!\d+(か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年))'
+    '^(たらず|以[下上])$': '(たらず|以[下上])'
 DurationUnitValueMap: !dictionary
   types: [string, long]
   entries:

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -9,7 +9,7 @@ MonthRegexForPeriod: !simpleRegex
 MonthNumRegexForPeriod: !simpleRegex
   def: (?<month>0?[1-9]|1[0-2])(?=\b|t|まで|から)?
 DayRegex: !simpleRegex
-  def: (?<day>[0-2]?[1-9]|[1-3]0|31)((日|目)(?!かかる|待つ|泊まる|経つ)間?)?
+  def: (?<day>[0-2]?[1-9]|[1-3]0|31)((日|目)(?!かかる|待つ|泊まる|経つ|都合)間?)?
 DayRegexForPeriod: !simpleRegex
   def: (?<day>3[01]|[0-2]?\d|(三十一?|(一|二)?十?[一二三四五六七八九]))((\s*日(?!かかる|待つ|泊まる|経つ))目?)?(?=\b|t|まで|から)?
 DayNumberRegex: !simpleRegex
@@ -23,23 +23,20 @@ MonthNumRegex: !simpleRegex
   def: (?<month>0?[1-9]|1[0-2])
 TwoNumYear: '50'
 YearNumRegex: !simpleRegex
-  def: ((?<year>(1[5-9]|20)\d{2}|2100)(?!\$|ドル|円|¥))(\s*年)?
+  def: ((?<year>((?<!(\+\d+(-|\s)(\d+(-|\s))?(\d+(-|\s))?)|([3-9][0-9]+(-|\s)))(1[5-9]|20)\d{2})|(?<!\d+(-|\s)\d+(-|\s)\d+(-|\s))2100)(?!\$|ドル|円|¥))(\s*年)?
 SimpleYearRegex: !simpleRegex
-  def: ((?<year>\d{2,4})(?!\$|ドル|円|¥))(\s*年)?
+  def: (今年)?((?<year>\d{2,4})(?!\$|ドル|円|¥))(\s*年)?
 ZeroToNineIntegerRegexCJK: !simpleRegex
   def: '[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨]'
 DynastyStartYear: '元'
 RegionTitleRegex: !simpleRegex
   def: (昭和|平成|令和|大正|明治|寛政|享和|文化|文政|天保|弘化|嘉永|安政|万延|文久|元治|慶応)
 DynastyYearRegex: !nestedRegex
-  def: (?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{1,2}|({ZeroToNineIntegerRegexCJK}){1,3}))年?
+  def: ((?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{1,2}|({ZeroToNineIntegerRegexCJK}){1,3}))年?)|(((?<Keio>慶応)|(?<Meiji>明治)|(?<Taisho>大正)|(?<Showa>昭和)|(?<Heisei>平成)|(?<Reiwa>令和))(\d+|元|{ZeroToNineIntegerRegexCJK})年)
   references: [RegionTitleRegex, DynastyStartYear, ZeroToNineIntegerRegexCJK]
 DateYearInCJKRegex: !nestedRegex
   def: (?<yearCJK>({ZeroToNineIntegerRegexCJK}{2,4}|{DynastyYearRegex}))年?
   references: [ZeroToNineIntegerRegexCJK, DynastyYearRegex]
-DynastyDatePeriodRegex: !nestedRegex
-  def: ({RegionTitleRegex}(\d{1,2}|{DayRegexNumInCJK})(\s*年)?({MonthRegex})?)
-  references: [RegionTitleRegex, DayRegexNumInCJK, MonthRegex ]
 WeekDayRegex: !simpleRegex
   def: (週(間)?の?)?(?<weekday>(日|月|火|水|木|金|土)曜日?)
 WeekDayStartEnd: !nestedRegex
@@ -48,13 +45,13 @@ WeekDayStartEnd: !nestedRegex
 LunarRegex: !simpleRegex
   def: (农历|初一|正月|大年|旧暦)
 DateThisRegex: !nestedRegex
-  def: (这个|这一个|这|这一|本|(?<week>今週)|そ|こ)(的|の)?({WeekDayRegex}|日)
+  def: (这个|这一个|这|这一|本|(?<week>今週)|これ?)(的|の)?({WeekDayRegex}|日)
   references: [WeekDayRegex]
 DateLastRegex: !nestedRegex
   def: (上一个|上个|上一|上|最后一个|最后|(?<week>先週)|最後)(的|の)?({WeekDayRegex}|日)
   references: [WeekDayRegex]
 DateNextRegex: !nestedRegex
-  def: (下一个|下个|下一|下|(?<week>来週)|次)(的|の)?{WeekDayRegex}
+  def: (下一个|下个|下一|下|(?<week>(来|翌)週)|次)(的|の)?{WeekDayRegex}
   references: [WeekDayRegex]
 WeekWithWeekDayRangeRegex: !nestedRegex
   def: ({DateThisRegex}|{DateNextRegex}|{DateLastRegex})(から)({WeekDayRegex})
@@ -64,15 +61,15 @@ WoMLastRegex: !simpleRegex
 WoMPreviousRegex: !simpleRegex
   def: 前
 WoMNextRegex: !simpleRegex
-  def: 次|来|これから(の)?
+  def: 次|翌|来|これから(の)?
 SpecialMonthRegex: !simpleRegex
   def: (先月|来月|今月|前月|再来月|昨月|先々月|ぜんげつ|(せん)?せんげつ|さくげつ|らいげつ|こんげつ)
 SpecialYearRegex: !simpleRegex
   def: (ことし|さ?らいねん|きょねん|さくねん)
 SpecialDayRegex: !simpleRegex
-  def: ((いっ)?さくじつ|おとつい|最近|前天|后天|明日から二日((?<today>今日)から(?<half>1日半)(の間)?)|((?<today>今日)から(?<half>2日半)(の間)?)|昨日の2日前|昨日から4日|今日から二日|今日から4日|昨日から2日間|昨天|明天|今天|今日|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日|最後の日)
+  def: ((いっ)?さくじつ|おとつい|最近(?!の)|前天|后天|明日から二日((?<today>今日)から(?<half>1日半)(の間)?)|((?<today>今日)から(?<half>2日半)(の間)?)|(?<today>本日)|昨日の2日前|昨日から4日|今日から二日|今日から4日|昨日から2日間|昨天|明天|今天|(?<!「)[今明]日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|(次の|翌|その|最後の)日)
 SpecialDayWithNumRegex: !simpleRegex
-  def: ((いっ)?さくじつ|おとつい|最近|前天|后天|昨天|明天|今天|今日?|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日)(から|の)?([\d十一二三四五六七八九]*|数)(日|月|週(間で)?|個)間?(先|後|前)?(の(?<weekday>日曜日?|月曜日?|火曜日?|水曜日?|木曜日?|金曜日?|土曜日?))?
+  def: ((いっ)?さくじつ|おとつい|最近(?!の)|前天|后天|昨天|明天|今天|(?<!「)今日?|明日|一?昨?昨日|一昨日|大后天|大前天|後天|大後天|きょう|あす|あした|きのう|明々後日|(弥)?明後日|この日|前日|二日前|おととい|し?あさって|私の一日|この間|次の日|その日)(から|の)?([\d十一二三四五六七八九]*|数)(日(?!都合)|月|週(間で)?|個)間?(先|後|前)?(の(?<weekday>日曜日?|月曜日?|火曜日?|水曜日?|木曜日?|金曜日?|土曜日?))?
 WeekDayOfMonthRegex: !nestedRegex
   def: ((({SpecialMonthRegex}|{MonthRegex}|{MonthNumRegex}|((这个|这一个|这|这一|本|今|上个|上一个|上|上一|去|下个|下一个|下|下一|明)月))(的|の)?\s*)?(第|最)?(?<cardinal>([初一二三四五])|最後|最終|([1-5])|最后一)(个|の|\s)*{WeekDayRegex})
   references: [SpecialMonthRegex, MonthRegex, MonthNumRegex, WeekDayRegex]
@@ -82,9 +79,9 @@ WeekDayAndDayRegex: !nestedRegex
 ThisPrefixRegex: !simpleRegex
   def: 这个|这一个|这|这一|本|今|こ
 LastPrefixRegex: !simpleRegex
-  def: 上个|上一个|上|上一|去|過去|最後|前|先|昨|最終
+  def: 上个|上一个|上|上一|去|過去|ここ|最後|前|先|昨|最終
 NextPrefixRegex: !simpleRegex
-  def: 下个|下一个|下|下一|明|次|再?来|向こう|これから(の)?|翌|向こう
+  def: 下个|下一个|下|下一|明(?!治)|次|再?来|向こう|これから(の)?|翌|向こう
 RelativeRegex: !nestedRegex
   def: (?<order>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex}))
   references: [ThisPrefixRegex, LastPrefixRegex, NextPrefixRegex]
@@ -108,7 +105,7 @@ DateRegexList2: !nestedRegex
   def: (({SimpleYearRegex}|{DateYearInCJKRegex}){MonthRegexForPeriod}\s*)
   references: [ MonthRegexForPeriod, SimpleYearRegex, DateYearInCJKRegex ]
 DateRegexList3: !nestedRegex
-  def: ((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?(から)?
+  def: ((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?
   references: [MonthRegex, DateDayRegexInCJK, SimpleYearRegex, LunarRegex, WeekDayRegex, DateYearInCJKRegex, DayRegex]
 # 7/23
 DateRegexList4: !nestedRegex
@@ -145,10 +142,9 @@ DateRegexList11: !nestedRegex
 # Note that these "Till" connector can be used without any suffix like "之间|之内|期间|中间|间"
 # DatePeriodExtractorCJK
 DatePeriodTillRegex: !simpleRegex
-  def: (?<till>到|至|から|--|-|—|——|~|–)
+  def: (?<till>到|至|から|--|-|—|——|~|–)(?!\d泊)
 DatePeriodRangeSuffixRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in Korean
-  def: ^\b$
+  def: (に?まで|の間)
 DatePeriodRangePrefixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^\b$
@@ -159,23 +155,23 @@ DatePeriodTillSuffixRequiredRegex: !simpleRegex
 DatePeriodDayRegexInCJK: !simpleRegex
   def: (?<day>(二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|二十二|二十三|二十一|十一|三十一|十二|十三|十四|十五|十六|十七|十八|十九|十|二十|三十|一|十|二|三|四|五|六|七|八|九|3[0-1]|[1-2]\d|0?[1-9])日|初一|三十|(一|十一|二十一|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|十|二十|三十|3[0-1]|[1-2]\d|0?[1-9])号|一|十一|二十一|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|十|二十|三十|廿(?!日市市)|卅)目?
 DatePeriodThisRegex: !simpleRegex
-  def: 今|这个|这一个|这|这一|本
+  def: (?<!「)今|这个|这一个|这|这一|本
 DatePeriodLastRegex: !simpleRegex
-  def:  この|上个|上一个|上|上一|前|去|最後|最終|過去|先|昨
+  def: この|上个|上一个|上|上一|前|去|最後|最終|過去|ここ|先|昨|前
 DatePeriodNextRegex: !simpleRegex
-  def: (?<after>再来|以降)|下个|下一个|下|下一|最初|来|向こう|これから(の)?|翌|今後|次(の)?
+  def: (?<after>再来|以降)|下个|下一个|下|下一|最初|来|向こう|これから(の)?|翌|今後|次(の)?|の後
 DateRangePrepositions: !simpleRegex
-  def: ((こ|私の|その|この|これらの|それらの)\s*)?
+  def: ((ひと|こ|私の|その|この|これらの|それらの)\s*)?
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)
   references: [DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex]
 HalfYearRegex: !simpleRegex
-  def: ((?<firstHalf>の?(上|前)半期)|(?<secondHalf>の?(下|后)半期))
+  def: ((?<firstHalf>の?(上|前)半期?)|(?<secondHalf>の?(下|后|後)半期?))
 YearRegex: !nestedRegex
-  def: (({YearNumRegex})(\s*年)?|({SimpleYearRegex})\s*年)(に)?{HalfYearRegex}?
-  references: [YearNumRegex, SimpleYearRegex, HalfYearRegex]
+  def: ((({YearNumRegex})(\s*年)?|({SimpleYearRegex})\s*年)(に)?{HalfYearRegex}?)|({DynastyYearRegex})
+  references: [YearNumRegex, SimpleYearRegex, HalfYearRegex, DynastyYearRegex]
 StrictYearRegex: !nestedRegex
-  def: (((こ|その|この|これらの|それらの)\s*)?{YearRegex})
+  def: (((ひと|こ|その|この|これらの|それらの)\s*)?{YearRegex})
   references: [YearRegex]
 YearRegexInNumber: !simpleRegex
   def: (?<year>(\d{3,4}))
@@ -186,27 +182,27 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>({RelativeMonthRegex}|{MonthRegex}))
   references: [RelativeMonthRegex, MonthRegex]
 SimpleCasesRegex: !nestedRegex
-  def: ({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex})\s*)?{MonthSuffixRegex}({DatePeriodDayRegexInCJK}|{DayRegex})\s*{DatePeriodTillRegex}\s*({DatePeriodDayRegexInCJK}|{DayRegex})((\s+|\s*,\s*){YearRegex})?(までの間|まで|の間)?
+  def: ({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex})\s*)?{MonthSuffixRegex}({DatePeriodDayRegexInCJK}|{DayRegex})\s*{DatePeriodTillRegex}\s*({DatePeriodDayRegexInCJK}|{DayRegex})(?!\d)((\s+|\s*,\s*){YearRegex})?(までの間|まで|の間)?
   references: [DateRangePrepositions, YearRegex, DatePeriodYearInCJKRegex, MonthSuffixRegex, DatePeriodDayRegexInCJK, DayRegex, DatePeriodTillRegex]
 YearAndMonth: !nestedRegex
-  def: ({YearNumRegex}の?\s*{MonthRegex}(\b|から)?)
-  references: [YearNumRegex, MonthRegex]
+  def: (({YearNumRegex}|{DateYearInCJKRegex})の?\s*{MonthRegex}(\b|から)?)
+  references: [YearNumRegex, MonthRegex, DateYearInCJKRegex]
 SimpleYearAndMonth: !nestedRegex
   def: ({DateRangePrepositions})({YearNumRegex}[/\\\-]{MonthNumRegex}(\b|から)$)
   references: [YearNumRegex, MonthNumRegex, DateRangePrepositions]
 PureNumYearAndMonth: !nestedRegex
-  def: ({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})
+  def: ({DateRangePrepositions})({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})(?!\d)|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})
   references: [YearRegexInNumber, MonthNumRegex, DateRangePrepositions]
 OneWordPeriodRegex: !nestedRegex
-  def: ({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>今年|再来年|翌年|去年|前年|后年|来年))(,|の(残り)?)?\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?の?\s*(数|\d\d?|{ZeroToNineIntegerRegexCJK})?(?<duration>ヶ?((?<!休|建国記念)日(?!付)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|週(間)?|年(?!々)(間)?|週間|今年|再来年|翌年|去年|前年|后年|来年))(?!間で)(?!で))(?<restof>の残りの日|いっぱい)?|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?
-  references: [DateRangePrepositions, MonthRegex, DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex, DayRegex, ZeroToNineIntegerRegexCJK]
+  def: ({DateRangePrepositions})((((周末|週(間)?|日間?|明年|(?<yearrel>(今|再来|翌|去|前|后|来)年))(,|の(残り)?)?\s*)?{MonthRegex}|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})の?\s*)?(数|\d\d?|{ZeroToNineIntegerRegexCJK}|(?<halfTag>半))?(?<duration>ヶ?((?<!休|建国記念)日(?!付|都合)間?|((?<!((?<![1-9]+)0+))月間?)|(週の)?週末|周末|周|(?<!よい一)週([間間])?|年(?!々|齢)(間|{HalfYearRegex})?|(今|再来|翌|去|前|后|来)年))(?!間で)(?!で))(の[前後](?<halfTag>半)|(?<restof>の残りの日|いっぱい)?)|(({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})({MonthRegex}(?!で)|{DayRegex})))(?<WithinNext>後に|以内に|初来)?
+  references: [DateRangePrepositions, MonthRegex, DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex, DayRegex, ZeroToNineIntegerRegexCJK, HalfYearRegex]
 LaterEarlyPeriodRegex: !simpleRegex 
-  def: ((?<next>来)|(?<this>今|同じ)|(?<last>この|去|先))?(?<suffix>(?<!建国記念)日(?!付)|(?<month>(\d))?((?<!((?<![1-9]+)0+))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>半ば)|(?<EarlyPrefix>(の)?初め|のはじめ|初旬|(?<RelEarly>ちょっと前に|上旬に))|(?<!の休日))
+  def: ((?<next>来|翌)|(?<this>今|同じ)|(?<last>この|去|先|前(の)?))?(?<suffix>(?<!建国記念)日(?!付)|(?<week>週(間)?)|(?<month>(正|一|二|三|四|五|六|七|八|九|十|十一|十二|0?[1-9]|1[0-2]))?((?<!((?<![1-9])0))|正|一|二|三|四|五|六|七|八|九|十|十一|十二)月|年(?!々|齢)|週)(?!間で)(?!で)((?<LatePrefix>(?<RelLate>の下旬|この後|の後半)|の終わり(ごろ)?|末|下旬)|(?<MidPrefix>(の)?(半ば|中旬))|(?<EarlyPrefix>(の)?初め|のはじめ|早くに|初旬|(?<RelEarly>ちょっと前に|上旬(に)?)))
 DatePointWithAgoAndLater: !simpleRegex
   def: ((?<today>今日)|(?<yesterday>昨日)|(?<tomorrow>明日))(から|の)(\d)(?<duration>週間|日)((?<within>以内)|(?<more>以上)(?<ago>前)|(?<more>以上(あと)?))
 WeekOfMonthRegex: !nestedRegex
-  def: ({DateRangePrepositions})((?<wom>{MonthSuffixRegex}(的|の))(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)
-  references: [DayRegex, DateRangePrepositions, MonthSuffixRegex, DatePeriodLastRegex, DatePeriodThisRegex, DatePeriodNextRegex]
+  def: ({DateRangePrepositions})((?<wom>({YearRegex}\s*)?{MonthSuffixRegex}(的|の))(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)
+  references: [DayRegex, DateRangePrepositions, MonthSuffixRegex, YearRegex, DatePeriodLastRegex, DatePeriodThisRegex, DatePeriodNextRegex]
 WeekOfYearRegex: !nestedRegex
   def: ({DateRangePrepositions})(?<woy>({YearRegex}|{RelativeRegex}年)(的|の)(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)
   references: [ YearRegex, RelativeRegex, DateRangePrepositions, DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex]
@@ -254,21 +250,21 @@ FirstLastOfYearRegex: !nestedRegex
   def: (({DatePeriodYearInCJKRegex}|{YearRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))的?)((?<first>前)|(?<last>(最后|最後|最終)))
   references: [YearRegex,DatePeriodYearInCJKRegex]
 ComplexDatePeriodRegex: !nestedRegex
-  def: ({DateRangePrepositions})(?<start>(第{ZeroToNineIntegerRegexCJK}+|第\d+|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex}|(({YearNumRegex}|{DayRegexForPeriod}|{DateDayRegexInCJK}|{MonthRegex}|{MonthNumRegex})(?!((\d+)?(分|秒|時))))|{RelativeRegex}).+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)
-  references: [ DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex, ZeroToNineIntegerRegexCJK, DateRangePrepositions, YearNumRegex, DayRegexForPeriod, WeekDayRegex, MonthRegex, MonthNumRegex, RelativeRegex, DateDayRegexInCJK ]
+  def: ({DateRangePrepositions})(?<start>.+)(から)(?<end>.+)(までの間|(?<!時)まで|の間)
+  references: [ DateRangePrepositions ]
 PastRegex: !simpleRegex
-  def: (?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|過去)(の)?)
+  def: (?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|ここ|過去)(の)?)
 FutureRegex: !simpleRegex
-  def: (?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これからの|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))
+  def: (?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これから(の)?|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))
 SeasonRegex: !simpleRegex
-  def: (?<season>春|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?
+  def: (?<season>春(?!節)|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?
 WhichWeekRegex: !simpleRegex
   def: 第(?<number>5[0-3]|[1-4]\d|0?[1-9])週
 SeasonWithYear: !nestedRegex
   def: ({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?{SeasonRegex}
   references: [YearRegex,DatePeriodYearInCJKRegex, SeasonRegex, DateRangePrepositions, ThisPrefixRegex, NextPrefixRegex, LastPrefixRegex]
 QuarterRegex: !nestedRegex
-  def: ({DateRangePrepositions})((({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)?(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)?))|(({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex})(四半期|クォーター))
+  def: ({DateRangePrepositions})((({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)?)|(第(?<cardinal>1|2|3|4|一|二|三|四)(四半期|クォーター)))|(({DatePeriodLastRegex}|{DatePeriodThisRegex}|{DatePeriodNextRegex})(四半期|クォーター))
   references: [DateRangePrepositions, YearRegex, DatePeriodYearInCJKRegex, DatePeriodLastRegex, DatePeriodThisRegex, DatePeriodNextRegex]
 CenturyNumRegex: !simpleRegex
   def: (?<century>\d|1\d|2\d)世紀
@@ -287,15 +283,15 @@ DecadeRegex: !nestedRegex
   references: [DateRangePrepositions, CenturyRegex, CenturyRegexInCJK, RelativeCenturyRegex, DecadeRegexInCJK]
 #DateTimeExtractorCJK
 PrepositionRegex: !simpleRegex
-  def: (?<prep>^(,?(夜の|的|の|t))|在$)
+  def: (?<prep>^(,?(夜の|的|の(?<timeOfDay>朝|夜|午後|晩)?|t),?|在)$)
 NowRegex: !simpleRegex
-  def: (?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(すぐ)?)
+  def: (?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(?!日)(すぐ)?)
 NightRegex: !simpleRegex
-  def: (?<night>早|晚|夜)
+  def: (?<night>早|晚|夜|泊(?=の?予約))
 TomorrowRegex: !simpleRegex
-  def: (?<tomorrow>明日の?(午前|午後|中|夜|朝)?)
+  def: (?<tomorrow>(?<!「)明日の?(午前|午後|中|夜|泊(?=の?予約)|朝)?)
 YesterdayRegex: !simpleRegex
-  def: (?<yesterday>昨日の?(午前|午後|中|夜|朝)?)
+  def: (?<yesterday>昨日の?(午前|午後|中|夜|泊(?=の?予約)|朝)?)
 TodayRegex: !simpleRegex
   def: (?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)
 FromNowRegex: !simpleRegex
@@ -310,9 +306,9 @@ SpecialDaySecondRegex: !nestedRegex
   def: ((?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex})秒間?)
   references: [TimeSecondCJKRegex, TimeSecondNumRegex]
 SpecialDayModRegex: !simpleRegex
-  def: ((?<after>過ぎに|以降)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))
+  def: ((?<after>過ぎに|以降)|(?<in>で)|(?<less>弱|たらず)|(?<more>以上))
 SpecialDayEndOfRegex: !nestedRegex
-  def: ((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))
+  def: ((?<SpecificEndOf>明日の終わり|今?({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))
   references: [WeekDayRegex]
 TimeOfSpecialDayRegex: !nestedRegex
   def: (({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})|({FromNowRegex}\d+(分|時|秒)後)
@@ -326,8 +322,16 @@ AsapTimeRegex: !simpleRegex
 #DateTimePeriodExtractorCJK
 DateTimePeriodTillRegex: !simpleRegex
   def: (?<till> 到|至|から|--|-|—|——|~)
+DateTimePeriodFromPrefixRegex: !simpleRegex
+  def: (从)
+DateTimePeriodFromSuffixRegex: !simpleRegex
+  def: (の間|まで(の間)?)
+DateTimePeriodConnectorRegex: !simpleRegex
+  def: (和|与|到)
 DateTimePeriodPrepositionRegex: !simpleRegex
-  def: (?<prep>^\s*(的|の(?!午))|在\s*$)
+  def: (?<prep>^\s*(的|の(?!午)|在)\s*$)
+BeforeAfterRegex: !simpleRegex
+  def: (前|後)
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -342,11 +346,11 @@ DateTimePeriodLastRegex: !simpleRegex
 DateTimePeriodNextRegex: !simpleRegex
   def: 下个|下一个|下|下一
 AmPmDescRegex: !simpleRegex
-  def: (?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))
+  def: (?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m|夜|晚|晩|午後|午后|午前(半ば|中)?|正午|真昼|夜中|深夜|昼食時|夕方に|朝|午後|昼(?!食)))
 TimeOfDayRegex: !simpleRegex
-  def: (?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|日|号)晩(?!上))
+  def: (?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|泊(?=の?予約)|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|泊(?=の?予約)|日|号)晩(?!上))
 SpecificTimeOfDayRegex: !nestedRegex
-  def: ((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))
+  def: ((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|泊(?=の?予約)|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))
   references: [DateTimePeriodThisRegex, DateTimePeriodNextRegex, DateTimePeriodLastRegex, TimeOfDayRegex, FutureRegex, PastRegex]
 DateTimePeriodUnitRegex: !simpleRegex
   def: (?<unit>(時|分|秒)間?)
@@ -357,7 +361,7 @@ DateTimePeriodNumberCombinedWithUnit: !nestedRegex
   def: \b(?<num>\d+(\.\d*)?){DateTimePeriodUnitRegex}
   references: [DateTimePeriodUnitRegex]
 PlusOneDayRegex: !simpleRegex
-  def: あす|あした|明日|来|次
+  def: あす|あした|明日|来|次|翌
 MinusOneDayRegex: !simpleRegex
   def: きのう|最後の日|前日|昨|昨日の?
 PlusTwoDayRegex: !simpleRegex
@@ -372,19 +376,19 @@ PlusFourDayRegex: !simpleRegex
   def: 今日から4日
 #DurationExtractorCJK
 DurationAllRegex: !simpleRegex
-  def: (まる(ひと)?)
+  def: (まる)
 DurationHalfRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^[.]
 DurationRelativeDurationUnitRegex: !simpleRegex
-  def: (?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|明日)|(?<another>(?<!に)もう)
+  def: (?<few>数ヶ|数)|(?<ago>(?<!以)前|昨日)|(?<within>以内)|(?<later>後|(?<!「)明日)|(?<another>(?<!(に))もう(?=\d)|別)の?(日|週|月)?
 AgoLaterRegex: !simpleRegex
-  def: (?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後)
+  def: (?<ago>(?<!午|(時\d\d?分))前)|(?<later>(?<!午)後|(?<!ま)で)
 DurationDuringRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^[.]
 DurationSomeRegex: !simpleRegex
-  def: (?<few>数(?<unit>((か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)
+  def: (?<few>数(?<unit>((か|ヶ)?(時|月|日(?!都合)|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)
 DurationMoreOrLessRegex: !simpleRegex
   def: (?<less>たらず)|(?<more>以上)
 DurationYearRegex: !simpleRegex
@@ -400,7 +404,7 @@ DurationSuffixList: !dictionary
     D: 天|日|日間
     BD: 営業日
     W: 星期|个星期|周|週間|週
-    MON: 个月|か月|月|月間|か月間|ヶ月|ヶ月間
+    MON: ひと月|月間|か月間|ヶ月|ヶ月間|个月|か月|月
     Y: 年|年間
 DurationAmbiguousUnits: !list
   types: [string]
@@ -417,9 +421,13 @@ DurationAmbiguousUnits: !list
     - 周
     - 个月
     - 年
+    - 時
+    - 時間
 DurationUnitRegex: !nestedRegex
   def: (?<unit>年|个月|月|周|時間?|(?<business>営業)日|天|週間?|星期|个星期|か月|(?<!(明|昨|今|((月|年)(の|、\s?)?(\d|{DayNumberRegex}))))日|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)
   references: [DayNumberRegex]
+AnUnitRegex: !simpleRegex
+  def: (?<another>別)の?(?<unit>日|年|月|時間?)
 DurationConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>[と]?|,)\s*$
 ConnectorRegex: !simpleRegex
@@ -428,7 +436,7 @@ LunarHolidayRegex: !nestedRegex
   def: (({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>除夕|春节|旧暦の正月初一|中秋(節|节)?|元宵(节|節)|端午(节|の節句)?|重(阳节|陽節))
   references: [YearRegex, DatePeriodYearInCJKRegex]
 HolidayRegexList1: !nestedRegex
-  def: (({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)
+  def: (旧暦の)?(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|の?独立記念日|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)(の\d日)?
   references: [YearRegex, DatePeriodYearInCJKRegex]
 HolidayRegexList2: !nestedRegex
   def: (({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>母(亲节|の日)|父亲节|感恩节|万圣节|ハロウィン)
@@ -437,7 +445,7 @@ HolidayRegexList2: !nestedRegex
 SetUnitRegex: !simpleRegex
   def: (?<unit>年|月|隔週|週|日|時|分|秒)
 SetEachUnitRegex: !nestedRegex
-  def: ((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<=\d)泊|(?<unit>隔週))
+  def: ((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<unit>隔週))
   references: [SetUnitRegex]
 SetEachPrefixRegex: !simpleRegex
   def: ((?<each>毎|隔|各|ごとに)\s*$)
@@ -486,20 +494,26 @@ TimeHalfRegex: !simpleRegex
 TimeQuarterRegex: !simpleRegex
   def: (?<quarter>[一两二三四1-4])\s*(刻钟|刻)
 # e.g: 十二点五十八分|半|一刻
+LessThanHalfHourRegex: !nestedRegex
+  def: (?<min>([0-2]?\d)|(二?十[一二三四五六七八九]?|[零〇一二三四五六七八九]))({TimeMinuteDescRegex})
+  references: [TimeMinuteDescRegex]
 TimeCJKTimeRegex: !nestedRegex
-  def: '{TimeHourRegex}({TimeQuarterRegex}|{TimeHalfRegex}|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?'
+  def: '{TimeHourRegex}({TimeQuarterRegex}|({TimeHalfRegex}({TimeSecondRegex})?)|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?'
   references: [TimeHourRegex, TimeQuarterRegex, TimeHalfRegex, TimeMinuteRegex, TimeSecondRegex]
 # e.g: 12:23
 TimeDigitTimeRegex: !nestedRegex
   def: (?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?({AmPmDescRegex})?
   references: [TimeHourNumRegex, TimeMinuteNumRegex, TimeSecondNumRegex, AmPmDescRegex]
+LessTimeRegex: !nestedRegex
+  def: (({TimeHourRegex}|(?<hour>{TimeHourNumRegex}):){LessThanHalfHourRegex}前)({AmPmDescRegex})?
+  references: [TimeHourRegex, LessThanHalfHourRegex, TimeHourNumRegex, AmPmDescRegex ]
 TimeDayDescRegex: !nestedRegex
-  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
+  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食)))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|泊(?=の?予約)|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
   references: [TimeDigitTimeRegex, TimeCJKTimeRegex]
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)
 TimeApproximateDescSuffixRegex: !simpleRegex
-  def: (ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり|以降|まで(の間)?|の間|間で?|間以内)
+  def: (過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)
 TimeRegexes1: !nestedRegex
   def: '{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?'
   references: [TimeApproximateDescPreffixRegex, TimeDayDescRegex, TimeDigitTimeRegex, TimeCJKTimeRegex, TimeApproximateDescSuffixRegex]
@@ -507,8 +521,8 @@ TimeRegexes2: !nestedRegex
   def: '({TimeApproximateDescPreffixRegex}(の)?)?{TimeDayDescRegex}((の)?{TimeApproximateDescSuffixRegex})?'
   references: [TimeApproximateDescPreffixRegex, TimeDayDescRegex, TimeApproximateDescSuffixRegex ]
 TimeRegexes3: !nestedRegex
-  def: ({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})前((の)?{TimeDayDescRegex})?
-  references: [TimeDigitTimeRegex, TimeCJKTimeRegex, TimeDayDescRegex]
+  def: ({TimeDayDescRegex}(の)?)?({LessTimeRegex})((の)?{TimeDayDescRegex})?
+  references: [LessTimeRegex, TimeDayDescRegex]
 #TimePeriodExtractorCJK
 TimePeriodTimePeriodConnectWords: !simpleRegex
   def: (まで(の間)?|の間|–|-|—|~|～)
@@ -534,7 +548,7 @@ TimePeriodRegexes1: !nestedRegex
   def: ({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})
   references: [TimePeriodLeftDigitTimeRegex, TimePeriodRightDigitTimeRegex, TimePeriodLeftCJKTimeRegex, TimePeriodRightCJKTimeRegex]
 TimePeriodRegexes2: !nestedRegex
-  def: (((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))
+  def: (((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼(?!食))(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))
   references: [TimePeriodShortLeftDigitTimeRegex, TimePeriodRightDigitTimeRegex, TimePeriodShortLeftCJKTimeRegex, TimePeriodRightCJKTimeRegex, TimeCJKTimeRegex, TimeDigitTimeRegex]
 #CJKDateTimeParserConfiguration
 FromToRegex: !simpleRegex
@@ -543,18 +557,24 @@ FromToRegex: !simpleRegex
 AmbiguousRangeModifierPrefix: !simpleRegex
   # TODO: modify below regex according to the counterpart in Chinese
   def: ^[.]
+UnspecificDatePeriodRegex: !simpleRegex
+  def: ^(の?(分|日|週|周|月|年|時間))$
 ReferenceDatePeriodRegex: !simpleRegex
   def: (同じ|その)(?<duration>月|週末|年|週)
 ParserConfigurationBefore: !simpleRegex
-  def: (またはその前|またはそれ以前|之前|以前|前)
+  def: ((?<include>(または|及び|と)そ)?の前|またはそれ以前|之前|以前|前|まで|以前)
 ParserConfigurationAfter: !simpleRegex
-  def: (またはそれ以降|之后|之後|以后|以後|后|後|以降)
+  def: (の後から|(?<include>または)それ以降|之后|之後|以后|以後|后|の?後|以降)
 ParserConfigurationUntil: !simpleRegex
-  def: (まで|直到|直至|截至|截止(到)?)
+  def: (直到|直至|截至|截止(到)?)
 ParserConfigurationSincePrefix: !simpleRegex
-  def: (自从|自|自打|打)
+  def: (自从|自|自打|打|早ければ)
 ParserConfigurationSinceSuffix: !simpleRegex
-  def: (以来|开始)
+  def: (またはその後|以来|开始|(?<!の後)から(?!\d(時|分|秒|月|日|\d?泊)))
+ParserConfigurationAroundPrefix: !simpleRegex
+  def: (ごろ|頃)
+ParserConfigurationAroundSuffix: !simpleRegex
+  def: (頃|ごろ)
 ParserConfigurationLastWeekDayRegex: 最后一个
 ParserConfigurationNextMonthRegex: 来月
 ParserConfigurationAfterNextMonthRegex: 再来月
@@ -593,6 +613,7 @@ ParserConfigurationUnitMap: !dictionary
     まる: whole
     まるひと: whole
     もう: another
+    別: another
     数: some
     たらず: less
     以上: more
@@ -625,6 +646,9 @@ MonthTerms: !list
   types: [ string ]
   entries:
     - 月
+    - 月間
+    - 月の前半
+    - 月の後半
 WeekendTerms: !list
   types: [ string ]
   entries:
@@ -637,19 +661,29 @@ WeekTerms: !list
     - 周
     - 週
     - 週間
+    - 週の前半
+    - 週の後半
 YearTerms: !list
   types: [ string ]
   entries:
     - 年
     - 年間
+    - 去年
+    - 今年
+    - 来年
 ThisYearTerms: !list
   types: [ string ]
   entries:
     - 今年
+YearToDateTerms: !list
+  types: [ string ]
+  entries:
+    - 年初来
 LastYearTerms: !list
   types: [ string ]
   entries:
     - 去年
+    - 前の年
 NextYearTerms: !list
   types: [ string ]
   entries:
@@ -683,6 +717,7 @@ ParserConfigurationCardinalMap: !dictionary
   entries:
     一: 1
     初: 1
+    最初: 1
     二: 2
     三: 3
     四: 4
@@ -910,6 +945,7 @@ ParserConfigurationMonthOfYear: !dictionary
     十月: 10
     十一月: 11
     十二月: 12
+    正月: 13
     1月: 1
     2月: 2
     3月: 3
@@ -950,27 +986,47 @@ DateTimeSimplePmRegex: !simpleRegex
 DateTimePeriodMORegex: !simpleRegex
   def: (朝|凌晨|清晨|早上|早|上午)
 DateTimePeriodMIRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in Chinese
-  def: ^[.]
+  def: 昼(?!食)
 DateTimePeriodAFRegex: !simpleRegex
   def: (中午|下午|午后|傍晚)
 DateTimePeriodEVRegex: !simpleRegex
   def: (晚上|夜里|夜晚|晚|晩)
 DateTimePeriodNIRegex: !simpleRegex
-  def: (半夜|夜间|深夜|夜)
+  def: (半夜|夜间|深夜|夜|泊(?=の?予約))
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    '早': '(?<!今|明|日|号)早(?!上)'
     '^\d{1,2}\.\d{1,2}$': '\d{1,2}\.\d{1,2}(?!\s*に[戻残]|から|で)'
+AmbiguityDateFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^今週$': '今週'
+AmbiguityDateTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    'から.+まで': ''
 AmbiguityDatePeriodFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     '^年$': '年'
+    '(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?': '(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?'
+AmbiguityTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^(\d+|[一二三四五六七八九十廿])時間$': '^(\d+|[一二三四五六七八九十廿])時間'
 AmbiguityDurationFiltersDict: !dictionary
   types: [ string, string ]
   entries:
+    '月': '(?<!ヶ|か|まるひと|もう1か)月(?!間|前|後)'
     '月に': '月に'
+    '月から': '月から'
+    '^十分$': '十分(?!前|後)'
+    '時間をつくっ': '時間をつくっ'
+    '年間$': '(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))年間'
+    '月間$': '(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数ヶか ]))月間'
+    '週間$': '(?<!([0-9]|[一二三四五六七八九十廿零壹贰叁肆伍陆柒捌玖〇两千俩倆仨半数 ]))週間'
+    '(日|週|月|年)間?$': '(よい|いい)([0-9]|[一二三四五六七八九十])?か?(日|週|月|年)間?'
+    '^(数ヶ|数|前|昨日|以内|後|明日|もう)$': '(数ヶ|数|前|昨日|以内|後|明日|もう)(?!\d+(か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年))'
 DurationUnitValueMap: !dictionary
   types: [string, long]
   entries:
@@ -1022,6 +1078,7 @@ TimeNumberDictionary: !dictionary
 TimeLowBoundDesc: !dictionary
   types: [string, int]
   entries:
+    泊: 18
     夜: 18 
     晚: 18
     晩: 18
@@ -1087,6 +1144,7 @@ NightTermList: !list
     - 深夜
     - 夜に
     - 夜
+    - 泊
     - 夜中
     - 夜間
 BusinessHourTermList: !list
@@ -1128,6 +1186,169 @@ DynastyYearMap: !dictionary
     文久: 1861
     元治: 1864
     慶応: 1865
+    平成二: 1990
+    平成元: 1989
+    昭和二: 1927
+    大正二: 1913
+    大正元: 1912
+    慶応4: 1868
+    明治元: 1868
+    明治2: 1869
+    明治3: 1870
+    明治4: 1871
+    明治5: 1872
+    明治6: 1873
+    明治7: 1874
+    明治8: 1875
+    明治9: 1876
+    明治10: 1877
+    明治11: 1878
+    明治12: 1879
+    明治13: 1880
+    明治14: 1881
+    明治15: 1882
+    明治16: 1883
+    明治17: 1884
+    明治18: 1885
+    明治19: 1886
+    明治20: 1887
+    明治21: 1888
+    明治22: 1889
+    明治23: 1890
+    明治24: 1891
+    明治25: 1892
+    明治26: 1893
+    明治27: 1894
+    明治28: 1895
+    明治29: 1896
+    明治30: 1897
+    明治31: 1898
+    明治32: 1899
+    明治33: 1900
+    明治34: 1901
+    明治35: 1902
+    明治36: 1903
+    明治37: 1904
+    明治38: 1905
+    明治39: 1906
+    明治40: 1907
+    明治41: 1908
+    明治42: 1909
+    明治43: 1910
+    明治44: 1911
+    明治45: 1912
+    大正元: 1912
+    大正2: 1913
+    大正3: 1914
+    大正4: 1915
+    大正5: 1916
+    大正6: 1917
+    大正7: 1918
+    大正8: 1919
+    大正9: 1920
+    大正10: 1921
+    大正11: 1922
+    大正12: 1923
+    大正13: 1924
+    大正14: 1925
+    大正15: 1926
+    昭和元: 1926
+    昭和64: 1989
+    昭和2: 1927
+    昭和3: 1928
+    昭和4: 1929
+    昭和5: 1930
+    昭和6: 1931
+    昭和7: 1932
+    昭和8: 1933
+    昭和9: 1934
+    昭和10: 1935
+    昭和11: 1936
+    昭和12: 1937
+    昭和13: 1938
+    昭和14: 1939
+    昭和15: 1940
+    昭和16: 1941
+    昭和17: 1942
+    昭和18: 1943
+    昭和19: 1944
+    昭和20: 1945
+    昭和21: 1946
+    昭和22: 1947
+    昭和23: 1948
+    昭和24: 1949
+    昭和25: 1950
+    昭和26: 1951
+    昭和27: 1952
+    昭和28: 1953
+    昭和29: 1954
+    昭和30: 1955
+    昭和31: 1956
+    昭和32: 1957
+    昭和33: 1958
+    昭和34: 1959
+    昭和35: 1960
+    昭和36: 1961
+    昭和37: 1962
+    昭和38: 1963
+    昭和39: 1964
+    昭和40: 1965
+    昭和41: 1966
+    昭和42: 1967
+    昭和43: 1968
+    昭和44: 1969
+    昭和45: 1970
+    昭和46: 1971
+    昭和47: 1972
+    昭和48: 1973
+    昭和49: 1974
+    昭和50: 1975
+    昭和51: 1976
+    昭和52: 1977
+    昭和53: 1978
+    昭和54: 1979
+    昭和55: 1980
+    昭和56: 1981
+    昭和57: 1982
+    昭和58: 1983
+    昭和59: 1984
+    昭和60: 1985
+    昭和61: 1986
+    昭和62: 1987
+    昭和63: 1988
+    平成2: 1990
+    平成3: 1991
+    平成4: 1992
+    平成5: 1993
+    平成6: 1994
+    平成7: 1995
+    平成8: 1996
+    平成9: 1997
+    平成10: 1998
+    平成11: 1999
+    平成12: 2000
+    平成13: 2001
+    平成14: 2002
+    平成15: 2003
+    平成16: 2004
+    平成17: 2005
+    平成18: 2006
+    平成19: 2007
+    平成20: 2008
+    平成21: 2009
+    平成22: 2010
+    平成23: 2011
+    平成24: 2012
+    平成25: 2013
+    平成26: 2014
+    平成27: 2015
+    平成28: 2016
+    平成29: 2017
+    平成30: 2018
+    平成31: 2019
+    令和元: 2019
+    令和2: 2020
+    令和3: 2021
 DayTypeRegex: !simpleRegex
   def: ^(天|日)$
 WeekTypeRegex: !simpleRegex

--- a/Patterns/Korean/Korean-DateTime.yaml
+++ b/Patterns/Korean/Korean-DateTime.yaml
@@ -980,6 +980,10 @@ AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     '^[.]': '^[.]'
+AmbiguityTimePeriodFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
 AmbiguityDateFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Korean/Korean-DateTime.yaml
+++ b/Patterns/Korean/Korean-DateTime.yaml
@@ -288,6 +288,8 @@ DateTimePeriodTillRegex: !simpleRegex
   def: (?<till>到|直到|--|-|—|——)
 DateTimePeriodPrepositionRegex: !simpleRegex
   def: (?<prep>^\s*的|在\s*$)
+BeforeAfterRegex: !simpleRegex
+  def: ^\b$
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -375,6 +377,8 @@ DurationAmbiguousUnits: !list
     - 시
 DurationUnitRegex: !simpleRegex
   def: (?<unit>(년|개?월|달|주일?|(?<!종)(?<=\d|\s+)일|(?<=\s)날|한나절|(?<=며)칠|시간?|분|초|영업일\s*기준으로|하루|이틀|사흘|나흘|닷새|엿새|이레|여드레|아흐레|열흘|하루|종일|내내|몇|여러|더|이상|이하|초과|미만)\s*(이상|이하|초과|미만)?)
+AnUnitRegex: !simpleRegex
+  def: ^[.]
 DurationConnectorRegex: !simpleRegex
   def: (?<connector>\s*그리고\s*|\s+|,\s*)
 ConnectorRegex: !simpleRegex
@@ -501,6 +505,9 @@ AmbiguousRangeModifierPrefix: !simpleRegex
 ReferenceDatePeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
   def: ^[.]
+UnspecificDatePeriodRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
 ParserConfigurationBefore: !simpleRegex
   def: ((?<include>和|或|及)?(之前|以前)|前)
 ParserConfigurationAfter: !simpleRegex
@@ -509,6 +516,12 @@ ParserConfigurationUntil: !simpleRegex
   def: (直到|直至|截至|截止(到)?)
 ParserConfigurationSincePrefix: !simpleRegex
   def: (自从|自|自打|打|从)
+ParserConfigurationAroundPrefix: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
+ParserConfigurationAroundSuffix: !simpleRegex
+  # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
 ParserConfigurationSinceSuffix: !simpleRegex
   def: (以来|开始|起)
 ParserConfigurationLastWeekDayRegex: 最后一个
@@ -598,6 +611,10 @@ ThisYearTerms: !list
   entries:
     - 금년
     - 올해
+YearToDateTerms: !list
+  types: [ string ]
+  entries:
+    - 올해 초부터 현재까지
 LastYearTerms: !list
   types: [ string ]
   entries:
@@ -959,6 +976,18 @@ DateTimePeriodEVRegex: !simpleRegex
   def: (晚上|夜里|夜晚|晚)
 DateTimePeriodNIRegex: !simpleRegex
   def: (半夜|夜间|深夜)
+AmbiguityTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
+AmbiguityDateFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
+AmbiguityDateTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^[.]': '^[.]'
 # For cases like "12号", singleWord "早" and "晚"
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -724,6 +724,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupported": "java, javascript, python",
     "Results": [
       {

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -729,9 +729,9 @@
         "Text": "本月十日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-03-10",
+          "Timex": "2017-03-10",
           "FutureResolution": {
-            "date": "2018-03-10"
+            "date": "2017-03-10"
           },
           "PastResolution": {
             "date": "2017-03-10"

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -724,6 +724,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "本月十日",

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -360,6 +360,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupported": "java, javascript, python",
     "Results": [
       {
@@ -826,7 +827,7 @@
               "start": "2016-11-06 05:00:00",
               "end": "2016-11-06 06:00:00"
             },
-			{
+            {
               "timex": "(2016-11-06T17:00,2016-11-06T18:00,PT1H)",
               "type": "datetimerange",
               "start": "2016-11-06 17:00:00",
@@ -1636,7 +1637,7 @@
               "start": "05:00:00",
               "end": "06:00:00"
             },
-			{
+            {
               "timex": "(T17:00,T18:00,PT1H)",
               "type": "timerange",
               "start": "17:00:00",

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -360,6 +360,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "本月十日",
@@ -812,6 +813,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "从昨天5:00-6:00",
@@ -1405,6 +1407,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "零点",
@@ -1428,6 +1431,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "零点整",
@@ -1619,6 +1623,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "5:00到6:00",

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -367,14 +367,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-03-10",
+              "timex": "2017-03-10",
               "type": "date",
               "value": "2017-03-10"
-            },
-            {
-              "timex": "XXXX-03-10",
-              "type": "date",
-              "value": "2018-03-10"
             }
           ]
         },
@@ -828,6 +823,12 @@
               "type": "datetimerange",
               "start": "2016-11-06 05:00:00",
               "end": "2016-11-06 06:00:00"
+            },
+			{
+              "timex": "(2016-11-06T17:00,2016-11-06T18:00,PT1H)",
+              "type": "datetimerange",
+              "start": "2016-11-06 17:00:00",
+              "end": "2016-11-06 18:00:00"
             }
           ]
         },
@@ -1414,11 +1415,6 @@
               "timex": "T00",
               "type": "time",
               "value": "00:00:00"
-            },
-            {
-              "timex": "T12",
-              "type": "time",
-              "value": "12:00:00"
             }
           ]
         },
@@ -1442,11 +1438,6 @@
               "timex": "T00",
               "type": "time",
               "value": "00:00:00"
-            },
-            {
-              "timex": "T12",
-              "type": "time",
-              "value": "12:00:00"
             }
           ]
         },
@@ -1639,6 +1630,12 @@
               "type": "timerange",
               "start": "05:00:00",
               "end": "06:00:00"
+            },
+			{
+              "timex": "(T17:00,T18:00,PT1H)",
+              "type": "timerange",
+              "start": "17:00:00",
+              "end": "18:00:00"
             }
           ]
         },

--- a/Specs/DateTime/Japanese/DateExtractor.json
+++ b/Specs/DateTime/Japanese/DateExtractor.json
@@ -842,16 +842,10 @@
     "NotSupportedByDesign": "javascript,python,java",
 	"Results": [
       {
-        "Text": "今週の金曜日",
+        "Text": "今週の金曜日6月15日",
         "Type": "date",
         "Start": 5,
-        "Length": 6
-      },
-      {
-        "Text": "6月15日",
-        "Type": "date",
-        "Start": 11,
-        "Length": 5
+        "Length": 11
       }
     ]
   },
@@ -863,16 +857,10 @@
     "NotSupportedByDesign": "javascript,python,java",
 	"Results": [
       {
-        "Text": "今週の金曜日",
+        "Text": "今週の金曜日(6月15日)",
         "Type": "date",
         "Start": 5,
-        "Length": 6
-      },
-      {
-        "Text": "6月15日",
-        "Type": "date",
-        "Start": 12,
-        "Length": 5
+        "Length": 13
       }
     ]
   },
@@ -884,16 +872,10 @@
     "NotSupportedByDesign": "javascript,python,java",
 	"Results": [
       {
-        "Text": "今週の金曜日",
+        "Text": "今週の金曜日6月22日",
         "Type": "date",
         "Start": 5,
-        "Length": 6
-      },
-      {
-        "Text": "6月22日",
-        "Type": "date",
-        "Start": 11,
-        "Length": 5
+        "Length": 11
       }
     ]
   },
@@ -905,16 +887,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の金曜日",
+        "Text": "今週の金曜日6月23日",
         "Type": "date",
         "Start": 5,
-        "Length": 6
-      },
-      {
-        "Text": "6月23日",
-        "Type": "date",
-        "Start": 11,
-        "Length": 5
+        "Length": 11
       }
     ]
   },
@@ -964,14 +940,14 @@
     ]
   },
   {
-    "Input": "コルタナ、2営業日以内にSkype通話を設定してください。",
+    "Input": "コルタナ、2営業日でSkype通話を設定してください。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2営業日以内",
+        "Text": "2営業日で",
         "Type": "date",
         "Start": 5,
-        "Length": 6
+        "Length": 5
       }
     ]
   },

--- a/Specs/DateTime/Japanese/DateParser.json
+++ b/Specs/DateTime/Japanese/DateParser.json
@@ -2185,12 +2185,12 @@
         "Text": "今月の27日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-11-27",
+          "Timex": "2016-11-27",
           "FutureResolution": {
             "date": "2016-11-27"
           },
           "PastResolution": {
-            "date": "2015-11-27"
+            "date": "2016-11-27"
           }
         },
         "Start": 2,
@@ -2234,12 +2234,12 @@
         "Text": "今月27日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-11-27",
+          "Timex": "2016-11-27",
           "FutureResolution": {
             "date": "2016-11-27"
           },
           "PastResolution": {
-            "date": "2015-11-27"
+            "date": "2016-11-27"
           }
         },
         "Start": 2,
@@ -2621,12 +2621,12 @@
         "Text": "来月の二十日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-12-20",
+          "Timex": "2016-12-20",
           "FutureResolution": {
             "date": "2016-12-20"
           },
           "PastResolution": {
-            "date": "2015-12-20"
+            "date": "2016-12-20"
           }
         },
         "Start": 2,
@@ -2645,7 +2645,7 @@
         "Text": "今月の三十一日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-11-31",
+          "Timex": "2016-11-31",
           "FutureResolution": {
             "date": "2016-12-31"
           },
@@ -2933,12 +2933,12 @@
         "Text": "次の月の20日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-01-20",
+          "Timex": "2018-01-20",
           "FutureResolution": {
             "date": "2018-01-20"
           },
           "PastResolution": {
-            "date": "2017-01-20"
+            "date": "2018-01-20"
           }
         },
         "Start": 4,
@@ -4205,9 +4205,9 @@
         "Text": "今月の十日",
         "Type": "date",
         "Value": {
-          "Timex": "XXXX-03-10",
+          "Timex": "2017-03-10",
           "FutureResolution": {
-            "date": "2018-03-10"
+            "date": "2017-03-10"
           },
           "PastResolution": {
             "date": "2017-03-10"

--- a/Specs/DateTime/Japanese/DateParser.json
+++ b/Specs/DateTime/Japanese/DateParser.json
@@ -2178,7 +2178,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "Fix needed: translated from 'the 27', w/o month term.",
+    "Comment": "Fix needed: translated from 'the 27', w/o month term. As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -2227,7 +2227,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "Fix needed: translated from 'the 27th', w/o month term.",
+    "Comment": "Fix needed: translated from 'the 27th', w/o month term. As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -2615,6 +2615,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -2639,6 +2640,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -2927,6 +2929,7 @@
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -3571,14 +3574,14 @@
     ]
   },
   {
-    "Input": "コルタナ、4営業日以内にSkypeコールをセットしてください。",
+    "Input": "コルタナ、4営業日でSkypeコールをセットしてください。",
     "Context": {
       "ReferenceDateTime": "2018-08-21T08:00:00"
     },
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
-        "Text": "4営業日以内",
+        "Text": "4営業日で",
         "Type": "date",
         "Value": {
           "Timex": "2018-08-27",
@@ -3590,7 +3593,7 @@
           }
         },
         "Start": 5,
-        "Length": 6
+        "Length": 5
       }
     ]
   },
@@ -4199,6 +4202,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "Comment": "As in English, expressions like '10th of the/this month' are resolved to the current month and year",
     "NotSupported": "javascript, python, java",
     "Results": [
       {

--- a/Specs/DateTime/Japanese/DateTimeExtractor.json
+++ b/Specs/DateTime/Japanese/DateTimeExtractor.json
@@ -148,10 +148,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "明日の午前8時ごろ",
+        "Text": "明日の午前8時",
         "Type": "datetime",
         "Start": 0,
-        "Length": 9
+        "Length": 7
       }
     ]
   },
@@ -376,10 +376,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今夜7時ごろ",
+        "Text": "今夜7時",
         "Type": "datetime",
         "Start": 0,
-        "Length": 6
+        "Length": 4
       }
     ]
   },
@@ -458,14 +458,7 @@
   {
     "Input": "日曜日のうちに戻ります。",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "日曜日のうちに",
-        "Type": "datetime",
-        "Start": 0,
-        "Length": 7
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "5日の午前4時に戻ります。",
@@ -920,6 +913,18 @@
         "Type": "datetime",
         "Start": 0,
         "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "日曜日の終わりに帰ります",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "日曜日の終わり",
+        "Type": "datetime",
+        "Start": 0,
+        "Length": 7
       }
     ]
   }

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -15910,6 +15910,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "日曜日の終わり",

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -54,7 +52,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -104,7 +100,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -130,7 +125,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -160,7 +154,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -190,7 +183,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -220,7 +212,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -250,7 +241,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -275,7 +265,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +289,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -330,7 +318,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -356,7 +343,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -388,7 +374,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -414,7 +399,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -440,7 +424,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -466,7 +449,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -498,7 +480,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -524,7 +505,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -549,7 +529,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -563,7 +542,7 @@
               "timex": "2016-11-08",
               "Mod": "since",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2016-11-08"
             }
           ]
@@ -576,7 +555,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -610,7 +588,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -637,7 +614,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -662,7 +638,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -692,7 +667,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -703,7 +677,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-11-08T08:00",
+              "timex": "2016-11-08T08",
               "type": "datetime",
               "value": "2016-11-08 08:00:00"
             }
@@ -717,7 +691,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -742,7 +715,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -767,7 +739,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -792,25 +763,24 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "日曜日のうちに",
+        "Text": "日曜日",
         "Start": 0,
-        "End": 6,
-        "TypeName": "datetimeV2.datetime",
+        "End": 2,
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-7T23:59:59",
-              "type": "datetime",
-              "value": "2016-11-06 23:59:59"
+              "timex": "XXXX-WXX-7",
+              "type": "date",
+              "value": "2016-11-06"
             },
             {
-              "timex": "XXXX-WXX-7T23:59:59",
-              "type": "datetime",
-              "value": "2016-11-13 23:59:59"
+              "timex": "XXXX-WXX-7",
+              "type": "date",
+              "value": "2016-11-13"
             }
           ]
         }
@@ -822,20 +792,19 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の日曜日のうちに",
+        "Text": "今週の日曜日",
         "Start": 0,
-        "End": 9,
-        "TypeName": "datetimeV2.datetime",
+        "End": 5,
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2016-11-13T23:59:59",
-              "type": "datetime",
-              "value": "2016-11-13 23:59:59"
+              "timex": "2016-11-13",
+              "type": "date",
+              "value": "2016-11-13"
             }
           ]
         }
@@ -847,7 +816,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -879,7 +847,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -911,7 +878,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -922,13 +888,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-08T03:00,2016-11-08T04:00,PT1H)",
+              "timex": "(2016-11-08T03,2016-11-08T04,PT1H)",
               "type": "datetimerange",
               "start": "2016-11-08 03:00:00",
               "end": "2016-11-08 04:00:00"
             },
             {
-              "timex": "(2016-11-08T15:00,2016-11-08T16:00,PT1H)",
+              "timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
               "type": "datetimerange",
               "start": "2016-11-08 15:00:00",
               "end": "2016-11-08 16:00:00"
@@ -943,7 +909,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -969,7 +934,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -995,7 +959,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1047,7 +1010,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1079,7 +1041,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1104,7 +1065,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1129,7 +1089,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1154,7 +1113,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1179,7 +1137,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1204,7 +1161,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1229,7 +1185,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1254,7 +1209,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1279,7 +1233,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1304,7 +1257,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1329,7 +1281,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1354,7 +1305,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1379,7 +1329,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1404,7 +1353,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1429,7 +1377,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1454,7 +1401,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1479,7 +1425,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1504,13 +1449,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後3時に",
+        "Text": "毎日午後3時",
         "Start": 0,
-        "End": 6,
+        "End": 5,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1529,7 +1473,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1554,7 +1497,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1579,7 +1521,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1604,7 +1545,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1634,7 +1574,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1659,7 +1598,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1670,9 +1608,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T07",
+              "timex": "T07:30",
               "type": "time",
-              "value": "07:00:00"
+              "value": "07:30:00"
             }
           ]
         }
@@ -1684,7 +1622,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1709,7 +1646,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1721,7 +1657,8 @@
           "values": [
             {
               "timex": "T12",
-              "type": "time",
+              "Mod": "approx",
+              "type": "timerange",
               "value": "12:00:00"
             }
           ]
@@ -1734,7 +1671,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1746,8 +1682,15 @@
           "values": [
             {
               "timex": "T11",
-              "type": "time",
+              "Mod": "approx",
+              "type": "timerange",
               "value": "11:00:00"
+            },
+            {
+              "timex": "T23",
+              "Mod": "approx",
+              "type": "timerange",
+              "value": "23:00:00"
             }
           ]
         }
@@ -1759,7 +1702,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1784,7 +1726,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1809,7 +1750,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1835,7 +1775,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1846,10 +1785,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T05,T07,PT2H)",
+              "timex": "(T05,T06,PT1H)",
               "type": "timerange",
               "start": "05:00:00",
-              "end": "07:00:00"
+              "end": "06:00:00"
             }
           ]
         }
@@ -1861,7 +1800,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1887,7 +1825,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1898,13 +1835,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T04:00,T07,PT3H)",
+              "timex": "(T04,T07,PT3H)",
               "type": "timerange",
               "start": "04:00:00",
               "end": "07:00:00"
             },
             {
-              "timex": "(T16:00,T19,PT3H)",
+              "timex": "(T16,T19,PT3H)",
               "type": "timerange",
               "start": "16:00:00",
               "end": "19:00:00"
@@ -1919,7 +1856,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1945,7 +1881,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1971,13 +1906,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午前中に",
+        "Text": "午前中",
         "Start": 0,
-        "End": 3,
+        "End": 2,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1997,7 +1931,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2023,7 +1956,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-28T14:11:10.9626841"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2048,7 +1980,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2073,7 +2004,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2098,35 +2028,20 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "来週の月曜日午前9時",
+        "Text": "来週の月曜日午前9時から午後1時",
         "Start": 0,
-        "End": 9,
-        "TypeName": "datetimeV2.datetime",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2017-12-11T09",
-              "type": "datetime",
-              "value": "2017-12-11 09:00:00"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "午後1時",
-        "Start": 12,
         "End": 15,
-        "TypeName": "datetimeV2.time",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "T13",
-              "type": "time",
-              "value": "13:00:00"
+              "timex": "(2017-12-11T09,2017-12-11T13,PT4H)",
+              "type": "datetimerange",
+              "start": "2017-12-11 09:00:00",
+              "end": "2017-12-11 13:00:00"
             }
           ]
         }
@@ -2138,7 +2053,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2183,7 +2097,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2228,7 +2141,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2270,7 +2182,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2318,7 +2229,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2363,7 +2273,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2408,7 +2317,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2417,7 +2325,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2426,7 +2333,6 @@
     "Context": {
       "ReferenceDateTime": "2018-01-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2456,7 +2362,6 @@
     "Context": {
       "ReferenceDateTime": "2018-01-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2488,7 +2393,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2533,7 +2437,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2565,7 +2468,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2574,7 +2476,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2583,7 +2484,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2592,7 +2492,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2601,7 +2500,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2610,7 +2508,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2635,7 +2532,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2644,7 +2540,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2653,7 +2548,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2662,7 +2556,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2704,20 +2597,20 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2週間以内に",
         "Start": 5,
         "End": 10,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-04-06",
-              "type": "date",
-              "value": "2018-04-06"
+              "timex": "(2018-03-23,2018-04-06,P2W)",
+              "type": "daterange",
+              "start": "2018-03-23",
+              "end": "2018-04-06"
             }
           ]
         }
@@ -2726,13 +2619,14 @@
         "Text": "2週間以内に",
         "Start": 20,
         "End": 25,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-04-06",
-              "type": "date",
-              "value": "2018-04-06"
+              "timex": "(2018-03-23,2018-04-06,P2W)",
+              "type": "daterange",
+              "start": "2018-03-23",
+              "end": "2018-04-06"
             }
           ]
         }
@@ -2744,7 +2638,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2786,7 +2679,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2857,7 +2749,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-25T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2898,13 +2789,12 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "月曜日の12時から4時まで",
+        "Text": "月曜日の12時から4時までの間",
         "Start": 5,
-        "End": 17,
+        "End": 19,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2946,9 +2836,9 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "月曜日の11時から4時まで",
+        "Text": "月曜日の11時から4時までの間",
         "Start": 5,
-        "End": 17,
+        "End": 19,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2986,7 +2876,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3011,7 +2900,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3052,7 +2940,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3130,7 +3017,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-17T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3157,7 +3043,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-08T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3184,7 +3069,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-11T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3211,7 +3095,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-08T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3263,7 +3146,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-22T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3316,7 +3198,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3327,11 +3208,11 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-05-18",
-              "Mod": "mid",
+              "timex": "2018-05-18TMI",
+              "Mod": "approx",
               "type": "datetimerange",
-              "start": "2018-05-18 10:00:00",
-              "end": "2018-05-18 14:00:00"
+              "start": "2018-05-18 11:00:00",
+              "end": "2018-05-18 13:00:00"
             }
           ]
         }
@@ -3370,7 +3251,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3396,7 +3276,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3422,7 +3301,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3448,7 +3326,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3473,7 +3350,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3482,7 +3358,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3491,7 +3366,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3500,7 +3374,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3526,7 +3399,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3552,7 +3424,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3584,7 +3455,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3596,6 +3466,7 @@
           "values": [
             {
               "timex": "2018-W22",
+              "Mod": "start",
               "type": "daterange",
               "start": "2018-05-28",
               "end": "2018-05-31"
@@ -3610,7 +3481,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3624,6 +3494,7 @@
               "timex": "2018-05",
               "type": "daterange",
               "start": "2018-05-01",
+              "Mod": "start",
               "end": "2018-05-16"
             }
           ]
@@ -3636,7 +3507,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3648,9 +3518,10 @@
           "values": [
             {
               "timex": "2018",
+              "Mod": "start",
               "type": "daterange",
               "start": "2018-01-01",
-              "end": "2018-05-28"
+              "end": "2018-07-01"
             }
           ]
         }
@@ -3662,7 +3533,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3674,6 +3544,7 @@
           "values": [
             {
               "timex": "2018-W22",
+              "Mod": "end",
               "type": "daterange",
               "start": "2018-05-31",
               "end": "2018-06-04"
@@ -3688,7 +3559,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3700,8 +3570,9 @@
           "values": [
             {
               "timex": "2018-05",
+              "Mod": "end",
               "type": "daterange",
-              "start": "2018-05-28",
+              "start": "2018-05-16",
               "end": "2018-06-01"
             }
           ]
@@ -3714,7 +3585,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3726,6 +3596,7 @@
           "values": [
             {
               "timex": "2018",
+              "Mod": "end",
               "type": "daterange",
               "start": "2018-07-01",
               "end": "2019-01-01"
@@ -3740,7 +3611,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3752,6 +3622,7 @@
           "values": [
             {
               "timex": "2018",
+              "Mod": "end",
               "type": "daterange",
               "start": "2018-07-01",
               "end": "2019-01-01"
@@ -3766,7 +3637,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3791,7 +3661,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3816,7 +3685,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3841,7 +3709,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3866,7 +3733,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3891,7 +3757,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3923,7 +3788,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3949,7 +3813,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3981,7 +3844,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4013,7 +3875,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4044,6 +3905,7 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2019-01-01"
             }
           ]
@@ -4056,7 +3918,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4070,6 +3931,7 @@
               "timex": "2010",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2011-01-01"
             }
           ]
@@ -4093,6 +3955,22 @@
         }
       },
       {
+        "Text": "1998年",
+        "Start": 24,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1998",
+              "type": "daterange",
+              "start": "1998-01-01",
+              "end": "1999-01-01"
+            }
+          ]
+        }
+      },
+      {
         "Text": "2000年以前",
         "Start": 32,
         "End": 38,
@@ -4105,22 +3983,6 @@
               "type": "daterange",
               "sourceEntity": "datetimerange",
               "end": "2000-01-01"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "1998",
-        "Start": 24,
-        "End": 27,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "1998",
-              "type": "daterange",
-              "start": "1998-01-01",
-              "end": "1999-01-01"
             }
           ]
         }
@@ -4192,7 +4054,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -4243,7 +4104,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4269,13 +4129,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-12T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今日から2週間以上",
+        "Text": "今日から2週間以上前",
         "Start": 0,
-        "End": 8,
+        "End": 9,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4283,7 +4142,6 @@
               "timex": "2018-05-29",
               "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
               "end": "2018-05-29"
             }
           ]
@@ -4296,7 +4154,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4310,7 +4167,6 @@
               "timex": "2018-05-26",
               "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
               "end": "2018-05-26"
             }
           ]
@@ -4323,7 +4179,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4349,7 +4204,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4400,7 +4254,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4419,16 +4272,16 @@
         }
       },
       {
-        "Text": "3分",
+        "Text": "3分後",
         "Start": 4,
-        "End": 5,
-        "TypeName": "datetimeV2.duration",
+        "End": 6,
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "PT3M",
-              "type": "duration",
-              "value": "180"
+              "timex": "2018-05-29T00:03:00",
+              "type": "datetime",
+              "value": "2018-05-29 00:03:00"
             }
           ]
         }
@@ -4440,7 +4293,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4486,7 +4338,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4512,7 +4363,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4538,7 +4388,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4552,6 +4401,7 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2019-01-01"
             }
           ]
@@ -4564,7 +4414,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4578,6 +4427,7 @@
               "timex": "2018-02",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2018-03-01"
             }
           ]
@@ -4590,7 +4440,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4601,15 +4450,17 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2015-01-01T02:00",
+              "timex": "2015-01-01T02",
               "Mod": "after",
               "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2015-01-01 02:00:00"
             },
             {
-              "timex": "2015-01-01T14:00",
+              "timex": "2015-01-01T14",
               "Mod": "after",
               "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2015-01-01 14:00:00"
             }
           ]
@@ -4649,7 +4500,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4663,6 +4513,7 @@
               "timex": "2018-07-04T10",
               "Mod": "after",
               "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2018-07-04 10:00:00"
             }
           ]
@@ -4702,7 +4553,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4713,31 +4563,31 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-02-01T06:00",
+              "timex": "XXXX-02-01T06",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2018-02-01 06:00:00"
             },
             {
-              "timex": "XXXX-02-01T06:00",
+              "timex": "XXXX-02-01T06",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2019-02-01 06:00:00"
             },
             {
-              "timex": "XXXX-02-01T18:00",
+              "timex": "XXXX-02-01T18",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2018-02-01 18:00:00"
             },
             {
-              "timex": "XXXX-02-01T18:00",
+              "timex": "XXXX-02-01T18",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2019-02-01 18:00:00"
             }
           ]
@@ -4750,7 +4600,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4777,15 +4626,17 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T02:00",
+              "timex": "T02",
               "Mod": "after",
               "type": "timerange",
+              "sourceEntity": "datetimepoint",
               "start": "02:00:00"
             },
             {
-              "timex": "T14:00",
+              "timex": "T14",
               "Mod": "after",
               "type": "timerange",
+              "sourceEntity": "datetimepoint",
               "start": "14:00:00"
             }
           ]
@@ -4798,7 +4649,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4818,9 +4668,9 @@
         }
       },
       {
-        "Text": "2009",
+        "Text": "2009年",
         "Start": 6,
-        "End": 9,
+        "End": 10,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4840,7 +4690,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4866,7 +4715,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4891,7 +4739,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4916,7 +4763,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4942,7 +4788,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4968,7 +4813,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4994,7 +4838,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5005,10 +4848,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-W29",
+              "timex": "2018-W28",
               "type": "daterange",
-              "start": "2018-07-16",
-              "end": "2018-07-23"
+              "start": "2018-07-09",
+              "end": "2018-07-16"
             }
           ]
         }
@@ -5020,7 +4863,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5046,7 +4888,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5071,7 +4912,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5096,7 +4936,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5121,7 +4960,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5146,13 +4984,12 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今日から2日後に",
+        "Text": "今日から2日後",
         "Start": 0,
-        "End": 7,
+        "End": 6,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -5171,7 +5008,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5197,7 +5033,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5223,7 +5058,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5249,7 +5083,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5275,7 +5108,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-06T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5305,7 +5137,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-06T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5388,7 +5219,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5414,7 +5244,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-11T20:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5444,7 +5273,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-13T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5478,7 +5306,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-13T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5518,7 +5345,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5529,10 +5355,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-07-16TNI",
+              "timex": "2018-07-16TEV",
               "type": "datetimerange",
-              "start": "2018-07-16 20:00:00",
-              "end": "2018-07-16 23:59:59"
+              "start": "2018-07-16 16:00:00",
+              "end": "2018-07-16 20:00:00"
             }
           ]
         }
@@ -5544,21 +5370,20 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "年",
-        "Start": 8,
+        "Text": "前の年",
+        "Start": 6,
         "End": 8,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018",
+              "timex": "2017",
               "type": "daterange",
-              "start": "2018-01-01",
-              "end": "2019-01-01"
+              "start": "2017-01-01",
+              "end": "2018-01-01"
             }
           ]
         }
@@ -5570,7 +5395,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5595,7 +5419,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-24T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5609,14 +5432,14 @@
               "timex": "XXXX-07-04",
               "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2018-07-04"
             },
             {
               "timex": "XXXX-07-04",
               "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2019-07-04"
             }
           ]
@@ -5693,7 +5516,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5719,7 +5541,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5730,10 +5551,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-08-15,P2W)",
+              "timex": "(2018-08-01,2018-08-22,P3W)",
               "type": "daterange",
               "start": "2018-08-01",
-              "end": "2018-08-15"
+              "end": "2018-08-22"
             }
           ]
         }
@@ -5745,7 +5566,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5770,7 +5590,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-30T20:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5800,29 +5619,28 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今日の午後",
+        "Text": "今日の午後から",
         "Start": 0,
-        "End": 4,
+        "End": 6,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-07-31TAF",
+              "Mod": "since",
               "type": "datetimerange",
-              "start": "2018-07-31 12:00:00",
-              "end": "2018-07-31 16:00:00"
+              "start": "2018-07-31 12:00:00"
             }
           ]
         }
       },
       {
-        "Text": "明日の午前",
+        "Text": "明日の午前中",
         "Start": 7,
-        "End": 11,
+        "End": 12,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5842,21 +5660,20 @@
     "Context": {
       "ReferenceDateTime": "2018-08-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "来週水曜日の夜",
+        "Text": "来週水曜日の夜に",
         "Start": 5,
-        "End": 11,
+        "End": 12,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-08-08TEV",
+              "timex": "2018-08-08TNI",
               "type": "datetimerange",
-              "start": "2018-08-08 16:00:00",
-              "end": "2018-08-08 20:00:00"
+              "start": "2018-08-08 20:00:00",
+              "end": "2018-08-08 23:59:59"
             }
           ]
         }
@@ -5868,21 +5685,20 @@
     "Context": {
       "ReferenceDateTime": "2018-08-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "来月の第一月曜日の夜",
+        "Text": "来月の第一月曜日の夜に",
         "Start": 5,
-        "End": 14,
+        "End": 15,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-09-WXX-1-#1TEV",
+              "timex": "XXXX-09-WXX-1-#1TNI",
               "type": "datetimerange",
-              "start": "2018-09-03 16:00:00",
-              "end": "2018-09-03 20:00:00"
+              "start": "2018-09-03 20:00:00",
+              "end": "2018-09-03 23:59:59"
             }
           ]
         }
@@ -5894,7 +5710,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5920,7 +5735,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5952,7 +5766,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5982,7 +5795,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6012,27 +5824,68 @@
     "Context": {
       "ReferenceDateTime": "2018-08-08T10:00:00"
     },
-    "Comment": "Only supported in CalendarMode",
-    "NotSupported": "dotnet",
+    "Comment": "In English this is supported only in CalendarMode, but in Japanese '日' unambiguously indicates a day",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+      {
+        "Text": "21日から23日の間",
+        "Start": 5,
+        "End": 14,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-01,XXXX-02-23,P22D)",
+              "type": "daterange",
+              "start": "2018-02-01",
+              "end": "2018-02-23"
+            },
+            {
+              "timex": "(XXXX-02-01,XXXX-02-23,P22D)",
+              "type": "daterange",
+              "start": "2019-02-01",
+              "end": "2019-02-23"
+            }
+          ]
+        }
+      }
+    ]
   },
   {
     "Input": "コルタナ、21日に何か設定してくれませんか。",
     "Context": {
       "ReferenceDateTime": "2018-08-08T10:00:00"
     },
-    "Comment": "Only supported in CalendarMode",
-    "NotSupported": "dotnet",
+    "Comment": "In English this is supported only in CalendarMode, but in Japanese '日' unambiguously indicates a day",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+      {
+        "Text": "21日",
+        "Start": 5,
+        "End": 7,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-XX-21",
+              "type": "date",
+              "value": "2018-07-21"
+            },
+            {
+              "timex": "XXXX-XX-21",
+              "type": "date",
+              "value": "2018-08-21"
+            }
+          ]
+        }
+      }
+    ]
   },
   {
     "Input": "おはよう、ポール。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -6041,7 +5894,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -6050,17 +5902,38 @@
     "Context": {
       "ReferenceDateTime": "2018-08-08T10:00:00"
     },
-    "Comment": "Only supported in CalendarMode",
-    "NotSupported": "dotnet",
+    "Comment": "In English this is supported only in CalendarMode, but in Japanese '日' unambiguously indicates a day",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+      {
+        "Text": "21日ごろ",
+        "Start": 5,
+        "End": 9,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-XX-21",
+              "Mod": "approx",
+              "type": "daterange",
+              "value": "2018-07-21"
+            },
+            {
+              "timex": "XXXX-XX-21",
+              "Mod": "approx",
+              "type": "daterange",
+              "value": "2018-08-21"
+            }
+          ]
+        }
+      }
+    ]
   },
   {
     "Input": "コルタナ、今月の21日ごろに何か設定してくれませんか。",
     "Context": {
       "ReferenceDateTime": "2018-08-08T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6086,7 +5959,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-16T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6155,20 +6027,20 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午前7時",
+        "Text": "午前7時まで",
         "Start": 0,
-        "End": 3,
+        "End": 5,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
-              "Mod": "until",
+              "timex": "T07",
+              "Mod": "before",
               "type": "timerange",
+              "sourceEntity": "datetimepoint",
               "end": "07:00:00"
             }
           ]
@@ -6181,21 +6053,19 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "明日",
         "Start": 0,
         "End": 1,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "2018-08-18",
-              "Mod": "until",
-              "type": "daterange",
-              "end": "2018-08-18"
+              "type": "date",
+              "value": "2018-08-18"
             }
           ]
         }
@@ -6207,7 +6077,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-20T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6234,7 +6103,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6288,7 +6156,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6318,13 +6185,27 @@
     "Context": {
       "ReferenceDateTime": "2018-08-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "火曜日の午後1時以降に",
+        "Text": "来週の月曜日",
+        "Start": 10,
+        "End": 15,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-03",
+              "type": "date",
+              "value": "2018-09-03"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "火曜日の午後1時以降",
         "Start": 17,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -6332,12 +6213,14 @@
               "timex": "XXXX-WXX-2T13",
               "Mod": "after",
               "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2018-08-28 13:00:00"
             },
             {
               "timex": "XXXX-WXX-2T13",
               "Mod": "after",
               "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2018-09-04 13:00:00"
             }
           ]
@@ -6357,21 +6240,6 @@
             }
           ]
         }
-      },
-      {
-        "Text": "来週の月曜日",
-        "Start": 10,
-        "End": 15,
-        "TypeName": "datetimeV2.date",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2018-09-03",
-              "type": "date",
-              "value": "2018-09-03"
-            }
-          ]
-        }
       }
     ]
   },
@@ -6380,7 +6248,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6406,7 +6273,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6432,7 +6298,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6443,10 +6308,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-31,2018-09-02,P2D)",
+              "timex": "(2018-08-28,2018-08-30,P2D)",
               "type": "daterange",
-              "start": "2018-08-31",
-              "end": "2018-09-02"
+              "start": "2018-08-28",
+              "end": "2018-08-30"
             }
           ]
         }
@@ -6458,21 +6323,19 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5分後",
         "Start": 0,
         "End": 2,
-        "TypeName": "datetimeV2.datetimerange",
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-30T10:00:00,2018-08-30T10:05:00,PT5M)",
-              "type": "datetimerange",
-              "start": "2018-08-30 10:00:00",
-              "end": "2018-08-30 10:05:00"
+              "timex": "2018-08-30T10:05:00",
+              "type": "datetime",
+              "value": "2018-08-30 10:05:00"
             }
           ]
         }
@@ -6484,7 +6347,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6510,7 +6372,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6536,7 +6397,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6562,7 +6422,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6588,7 +6447,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-06T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6615,7 +6473,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6629,6 +6486,7 @@
               "timex": "2012",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2013-01-01"
             }
           ]
@@ -6641,7 +6499,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6653,10 +6510,10 @@
           "values": [
             {
               "timex": "2012",
-              "Mod": "since",
+              "Mod": "after",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "start": "2012-01-01"
+              "start": "2013-01-01"
             }
           ]
         }
@@ -6668,7 +6525,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6680,10 +6536,10 @@
           "values": [
             {
               "timex": "2016",
-              "Mod": "since",
+              "Mod": "after",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "start": "2016-01-01"
+              "start": "2017-01-01"
             }
           ]
         }
@@ -6695,7 +6551,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6707,9 +6562,9 @@
           "values": [
             {
               "timex": "2016-01-01",
-              "Mod": "since",
+              "Mod": "after",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "2016-01-01"
             }
           ]
@@ -6723,7 +6578,6 @@
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
     "Comment": "Known false positive needs to be supported in the future",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6746,38 +6600,23 @@
   {
     "Input": "2016年1月1日の午後6時以降にしか出発できません。",
     "Context": {
-      "ReferenceDateTime": "2018-08-31T12:00:00"
+      "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2016年1月1日",
+        "Text": "2016年1月1日の午後6時以降",
         "Start": 0,
-        "End": 8,
-        "TypeName": "datetimeV2.date",
+        "End": 15,
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2016-01-01",
-              "type": "date",
-              "value": "2016-01-01"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "午後6時以降に",
-        "Start": 10,
-        "End": 16,
-        "TypeName": "datetimeV2.timerange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "T18",
+              "timex": "2016-01-01T18",
               "Mod": "after",
-              "type": "timerange",
-              "start": "18:00:00"
+              "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
+              "start": "2016-01-01 18:00:00"
             }
           ]
         }
@@ -6789,7 +6628,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6815,7 +6653,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6827,10 +6664,10 @@
           "values": [
             {
               "timex": "2018",
-              "Mod": "since",
+              "Mod": "after",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "start": "2018-01-01"
+              "start": "2019-01-01"
             }
           ]
         }
@@ -6842,7 +6679,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6872,6 +6708,7 @@
               "timex": "2020",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2021-01-01"
             }
           ]
@@ -6884,7 +6721,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6911,10 +6747,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
-              "Mod": "since",
+              "timex": "T07",
+              "Mod": "after",
               "type": "timerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "start": "07:00:00"
             }
           ]
@@ -6927,7 +6763,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6941,6 +6776,7 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2019-01-01"
             }
           ]
@@ -6953,7 +6789,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6993,7 +6828,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7007,7 +6841,7 @@
               "timex": "T14:30",
               "Mod": "before",
               "type": "timerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "14:30:00"
             }
           ]
@@ -7020,7 +6854,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7031,12 +6864,12 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-03-29T11:00",
+              "timex": "XXXX-03-29T11",
               "type": "datetime",
               "value": "2018-03-29 11:00:00"
             },
             {
-              "timex": "XXXX-03-29T11:00",
+              "timex": "XXXX-03-29T11",
               "type": "datetime",
               "value": "2019-03-29 11:00:00"
             }
@@ -7050,7 +6883,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7082,7 +6914,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7114,7 +6945,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7125,7 +6955,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -7140,7 +6970,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7151,7 +6980,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -7166,7 +6995,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7198,7 +7026,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7209,7 +7036,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"
@@ -7224,7 +7051,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7256,7 +7082,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -7265,7 +7090,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7295,7 +7119,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-17T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7335,7 +7158,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-17T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7357,13 +7179,13 @@
         "Text": "一週間",
         "Start": 21,
         "End": 23,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-10-24",
-              "type": "date",
-              "value": "2018-10-24"
+              "timex": "P1W",
+              "type": "duration",
+              "value": "604800"
             }
           ]
         }
@@ -7375,7 +7197,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7407,7 +7228,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7433,7 +7253,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7459,7 +7278,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7481,15 +7299,14 @@
     ]
   },
   {
-    "Input": "2017年11月から2月までAPECが韓国で行われる。",
+    "Input": "11月から2017年2月までAPECが韓国で行われる。",
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2017年11月から2月まで",
+        "Text": "11月から2017年2月まで",
         "Start": 0,
         "End": 13,
         "TypeName": "datetimeV2.daterange",
@@ -7507,15 +7324,14 @@
     ]
   },
   {
-    "Input": "2017年11月から2月5日までAPECが韓国で行われる。",
+    "Input": "11月から2017年2月5日までAPECが韓国で行われる。",
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2017年11月から2月5日まで",
+        "Text": "11月から2017年2月5日まで",
         "Start": 0,
         "End": 15,
         "TypeName": "datetimeV2.daterange",
@@ -7537,7 +7353,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7563,7 +7378,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7589,7 +7403,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7621,7 +7434,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7632,9 +7444,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2020-10-01,P29M)",
+              "timex": "(2020-05-01,2020-10-01,P5M)",
               "type": "daterange",
-              "start": "2018-05-01",
+              "start": "2020-05-01",
               "end": "2020-10-01"
             }
           ]
@@ -7647,7 +7459,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7673,7 +7484,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7699,7 +7509,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7725,9 +7534,23 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
+      {
+        "Text": "その日",
+        "Start": 0,
+        "End": 2,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-10-24",
+              "type": "date",
+              "value": "2018-10-24"
+            }
+          ]
+        }
+      },
       {
         "Text": "2016年8月5日",
         "Start": 5,
@@ -7750,7 +7573,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7782,7 +7604,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7808,7 +7629,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7819,7 +7639,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-10-31T8,2018-10-31T15,PT7H)",
+              "timex": "(2018-10-31T08,2018-10-31T15,PT7H)",
               "type": "datetimerange",
               "start": "2018-10-31 08:00:00",
               "end": "2018-10-31 15:00:00"
@@ -7834,7 +7654,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7878,7 +7697,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7910,7 +7728,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7936,7 +7753,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7962,7 +7778,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7994,7 +7809,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8020,7 +7834,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8046,13 +7859,12 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2018年12月から2019年5月",
+        "Text": "2018年12月から2019年5月まで",
         "Start": 0,
-        "End": 16,
+        "End": 18,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8072,7 +7884,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8097,7 +7908,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8122,7 +7932,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8131,7 +7940,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-15T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8171,7 +7979,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-15T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8211,7 +8018,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-15T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8271,7 +8077,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8296,7 +8101,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8321,7 +8125,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8346,7 +8149,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8431,7 +8233,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8456,7 +8257,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8481,7 +8281,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-23T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8508,7 +8307,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8558,7 +8356,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-27T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8585,21 +8382,19 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "週末",
-        "Start": 10,
+        "Text": "今週末",
+        "Start": 9,
         "End": 11,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-W48",
-              "Mod": "end",
+              "timex": "2018-W48-WE",
               "type": "daterange",
-              "start": "2018-11-29",
+              "start": "2018-12-01",
               "end": "2018-12-03"
             }
           ]
@@ -8613,7 +8408,6 @@
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
     "Comment": "between 9-6 PT can't be extracted as TimeZone is not enabled for now",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8675,6 +8469,28 @@
             }
           ]
         }
+      },
+      {
+        "Text": "6時から9時の間",
+        "Start": 18,
+        "End": 25,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T06,T09,PT3H)",
+              "type": "timerange",
+              "start": "06:00:00",
+              "end": "09:00:00"
+            },
+            {
+              "timex": "(T18,T21,PT3H)",
+              "type": "timerange",
+              "start": "18:00:00",
+              "end": "21:00:00"
+            }
+          ]
+        }
       }
     ]
   },
@@ -8684,8 +8500,7 @@
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
     "Comment": "Not supported as the TimeZone is not enabled for now",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "dotnet,javascript,python,java",
     "Results": [
       {
         "Text": "太平洋標準時の6時30分から9時の間",
@@ -8722,7 +8537,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8748,7 +8562,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8774,7 +8587,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8800,7 +8612,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8826,7 +8637,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8852,7 +8662,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8884,7 +8693,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8911,7 +8719,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8924,7 +8731,8 @@
             {
               "timex": "2018-W48",
               "type": "daterange",
-              "start": "2018-11-30",
+              "Mod": "end",
+              "start": "2018-11-29",
               "end": "2018-12-03"
             }
           ]
@@ -8937,7 +8745,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8962,7 +8769,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-05T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8987,7 +8793,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-05T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8998,9 +8803,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "P1.25Y",
+              "timex": "P1Y3M",
               "type": "duration",
-              "value": "39420000"
+              "value": "39312000"
             }
           ]
         }
@@ -9012,7 +8817,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9021,7 +8825,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9031,7 +8834,6 @@
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
     "Comment": "Not extracted may as a datetime range is not supported for now",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9040,7 +8842,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-13T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9049,7 +8850,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9109,7 +8909,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9134,7 +8933,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9164,7 +8962,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9194,7 +8991,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9208,12 +9004,14 @@
               "timex": "XXXX-05",
               "Mod": "after-mid",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2018-05-21"
             },
             {
               "timex": "XXXX-05",
               "Mod": "after-mid",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2019-05-21"
             }
           ]
@@ -9226,7 +9024,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9240,12 +9037,14 @@
               "timex": "XXXX-09",
               "Mod": "before-start",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "end": "2018-09-01"
             },
             {
               "timex": "XXXX-09",
               "Mod": "before-start",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "end": "2019-09-01"
             }
           ]
@@ -9258,7 +9057,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9270,15 +9068,17 @@
           "values": [
             {
               "timex": "XXXX-07",
-              "Mod": "since-end",
+              "Mod": "after-end",
               "type": "daterange",
-              "start": "2018-07-16"
+              "sourceEntity": "datetimerange",
+              "start": "2018-08-01"
             },
             {
               "timex": "XXXX-07",
-              "Mod": "since-end",
+              "Mod": "after-end",
               "type": "daterange",
-              "start": "2019-07-16"
+              "sourceEntity": "datetimerange",
+              "start": "2019-08-01"
             }
           ]
         }
@@ -9290,7 +9090,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9299,7 +9098,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9324,7 +9122,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9349,7 +9146,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9374,7 +9170,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9399,7 +9194,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9410,9 +9204,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-01-30",
+              "timex": "2019-01-23",
               "type": "date",
-              "value": "2019-01-30"
+              "value": "2019-01-23"
             }
           ]
         }
@@ -9424,27 +9218,38 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "7時30分から9時30分の間",
-        "Start": 4,
+        "Text": "12日の7時30分から9時30分の間",
+        "Start": 0,
         "End": 17,
-        "TypeName": "datetimeV2.timerange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(T07:30,T09:30,PT2H)",
-              "type": "timerange",
-              "start": "07:30:00",
-              "end": "09:30:00"
+              "timex": "(XXXX-XX-12T07:30,XXXX-XX-12T09:30,PT2H)",
+              "type": "datetimerange",
+              "start": "2019-01-12 07:30:00",
+              "end": "2019-01-12 09:30:00"
             },
             {
-              "timex": "(T19:30,T21:30,PT2H)",
-              "type": "timerange",
-              "start": "19:30:00",
-              "end": "21:30:00"
+              "timex": "(XXXX-XX-12T07:30,XXXX-XX-12T09:30,PT2H)",
+              "type": "datetimerange",
+              "start": "2019-02-12 07:30:00",
+              "end": "2019-02-12 09:30:00"
+            },
+            {
+              "timex": "(XXXX-XX-12T19:30,XXXX-XX-12T21:30,PT2H)",
+              "type": "datetimerange",
+              "start": "2019-01-12 19:30:00",
+              "end": "2019-01-12 21:30:00"
+            },
+            {
+              "timex": "(XXXX-XX-12T19:30,XXXX-XX-12T21:30,PT2H)",
+              "type": "datetimerange",
+              "start": "2019-02-12 19:30:00",
+              "end": "2019-02-12 21:30:00"
             }
           ]
         }
@@ -9456,7 +9261,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9488,7 +9292,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9520,7 +9323,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9531,13 +9333,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-1T09:30,XXXX-WXX-1T15:00,PT5H30M)",
+              "timex": "(XXXX-WXX-1T09:30,XXXX-WXX-1T15,PT5H30M)",
               "type": "datetimerange",
               "start": "2019-01-21 09:30:00",
               "end": "2019-01-21 15:00:00"
             },
             {
-              "timex": "(XXXX-WXX-1T09:30,XXXX-WXX-1T15:00,PT5H30M)",
+              "timex": "(XXXX-WXX-1T09:30,XXXX-WXX-1T15,PT5H30M)",
               "type": "datetimerange",
               "start": "2019-10-21 09:30:00",
               "end": "2019-10-21 15:00:00"
@@ -9552,7 +9354,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9563,13 +9364,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M",
+              "timex": "(XXXX-01-15T13,XXXX-01-15T13:15,PT15M)",
               "type": "datetimerange",
               "start": "2019-01-15 13:00:00",
               "end": "2019-01-15 13:15:00"
             },
             {
-              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M",
+              "timex": "(XXXX-01-15T13,XXXX-01-15T13:15,PT15M)",
               "type": "datetimerange",
               "start": "2020-01-15 13:00:00",
               "end": "2020-01-15 13:15:00"
@@ -9584,7 +9385,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9624,7 +9424,6 @@
     "Context": {
       "ReferenceDateTime": "2019-03-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9643,20 +9442,20 @@
         }
       },
       {
-        "Text": "木曜日の19時から21時",
+        "Text": "木曜日の19時から21時で",
         "Start": 12,
-        "End": 23,
+        "End": 24,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-4T19:00,XXXX-WXX-4T21:00,PT2H)",
+              "timex": "(XXXX-WXX-4T19,XXXX-WXX-4T21,PT2H)",
               "type": "datetimerange",
               "start": "2019-02-28 19:00:00",
               "end": "2019-02-28 21:00:00"
             },
             {
-              "timex": "(XXXX-WXX-4T19:00,XXXX-WXX-4T21:00,PT2H)",
+              "timex": "(XXXX-WXX-4T19,XXXX-WXX-4T21,PT2H)",
               "type": "datetimerange",
               "start": "2019-03-07 19:00:00",
               "end": "2019-03-07 21:00:00"
@@ -9671,7 +9470,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9697,16 +9495,31 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2015年",
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
   },
   {
     "Input": "電話番号: +86 138-2010-2015",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9715,7 +9528,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9724,7 +9536,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9733,7 +9544,6 @@
     "Context": {
       "ReferenceDateTime": "2019-07-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9759,7 +9569,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2019",
@@ -9784,10 +9594,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "３月から５月まで",
+        "Text": "3月から5月まで",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -9815,7 +9625,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "17:55:23-18:33:02",
@@ -9823,7 +9633,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+              "timex": "(T17:55:23,T18:33:02,PT37M39S)",
               "type": "timerange",
               "start": "17:55:23",
               "end": "18:33:02"
@@ -9840,10 +9650,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００７年１月１０日またはその前",
+        "Text": "2007年1月10日またはその前",
         "Start": 0,
         "End": 15,
         "TypeName": "datetimeV2.daterange",
@@ -9854,7 +9664,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2007-01-10"
+              "end": "2007-01-10"
             }
           ]
         }
@@ -9862,42 +9672,24 @@
     ]
   },
   {
-    "Input": "２０１０年１月１０日から２０１２年１月７日の前まで、単位は中間値に超さないインタネット接続はどれですか？",
+    "Input": "２０１０年１月１０日から２０１２年１月７日で、単位は中間値に超さないインタネット接続はどれですか？",
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年１月１０日から",
+        "Text": "2010年1月10日から2012年1月7日",
         "Start": 0,
-        "End": 11,
+        "End": 20,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2010-01-10",
-              "Mod": "since",
+              "timex": "(2010-01-10,2012-01-07,P727D)",
               "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "２０１２年１月７日の前まで",
-        "Start": 12,
-        "End": 24,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2011-01-07",
-              "Mod": "before",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "end": "2011-01-07"
+              "start": "2010-01-10",
+              "end": "2012-01-07"
             }
           ]
         }
@@ -9909,10 +9701,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年前",
+        "Text": "2018年前",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -9935,7 +9727,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今月の半ばまで",
@@ -9945,10 +9737,11 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2019-09-01,2019-09-16,P15D)",
+              "timex": "2019-09",
+              "Mod": "before-mid",
               "type": "daterange",
-              "start": "2019-09-01",
-              "end": "2019-09-16"
+              "sourceEntity": "datetimerange",
+              "end": "2019-09-10"
             }
           ]
         }
@@ -9960,7 +9753,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2018年7月9日またはその前",
@@ -9974,7 +9767,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2018-07-09"
+              "end": "2018-07-09"
             }
           ]
         }
@@ -9986,7 +9779,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今夜六時",
@@ -10010,10 +9803,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "今朝８時１５分",
+        "Text": "今朝8時15分",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -10034,7 +9827,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-28T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日",
@@ -10058,7 +9851,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "先週",
@@ -10066,10 +9859,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2017-03-15,2017-03-22,P1W)",
+              "timex": "2017-W11",
               "type": "daterange",
-              "start": "2017-03-15",
-              "end": "2017-03-22"
+              "start": "2017-03-13",
+              "end": "2017-03-20"
             }
           ]
         },
@@ -10083,7 +9876,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "五時から六時まで",
@@ -10091,10 +9884,16 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T05:00,T06:00,PT1H)",
+              "timex": "(T05,T06,PT1H)",
               "type": "timerange",
               "start": "05:00:00",
               "end": "06:00:00"
+            },
+            {
+              "timex": "(T17,T18,PT1H)",
+              "type": "timerange",
+              "start": "17:00:00",
+              "end": "18:00:00"
             }
           ]
         },
@@ -10108,12 +9907,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "５年前に",
+        "Text": "5年前",
         "Start": 0,
-        "End": 3,
+        "End": 2,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -10132,10 +9931,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１６年から２０１８年まで",
+        "Text": "2016年から2018年まで",
         "Start": 0,
         "End": 13,
         "TypeName": "datetimeV2.daterange",
@@ -10157,7 +9956,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-24T16:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "過去の十年間",
@@ -10182,7 +9981,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-28T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今日",
@@ -10206,10 +10005,10 @@
     "Context": {
       "ReferenceDateTime": "2016-02-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２９日",
+        "Text": "29日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -10235,15 +10034,15 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１７時５５分２３秒から１８時３３分２秒まで",
+        "Text": "17時55分23秒から18時33分2秒まで",
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+              "timex": "(T17:55:23,T18:33:02,PT37M39S)",
               "type": "timerange",
               "start": "17:55:23",
               "end": "18:33:02"
@@ -10260,7 +10059,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の三時間",
@@ -10285,7 +10084,7 @@
     "Context": {
       "ReferenceDateTime": "2018-12-14T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "三十分",
@@ -10295,7 +10094,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "PT0.5H",
+              "timex": "PT30M",
               "type": "duration",
               "value": "1800"
             }
@@ -10309,7 +10108,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨夜",
@@ -10317,10 +10116,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-11-06TEV",
+              "timex": "2016-11-06TNI",
               "type": "datetimerange",
-              "start": "2016-11-06 16:00:00",
-              "end": "2016-11-06 20:00:00"
+              "start": "2016-11-06 20:00:00",
+              "end": "2016-11-06 23:59:59"
             }
           ]
         },
@@ -10334,15 +10133,15 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "午後五時から朝３時まで",
+        "Text": "午後五時から朝3時まで",
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:00,T03:00,PT10H)",
+              "timex": "(T17,T03,PT10H)",
               "type": "timerange",
               "start": "17:00:00",
               "end": "03:00:00"
@@ -10359,21 +10158,23 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０時ごろ",
+        "Text": "10時ごろ",
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T10",
-              "type": "time",
+              "Mod": "approx",
+              "type": "timerange",
               "value": "10:00:00"
             },
             {
               "timex": "T22",
-              "type": "time",
+              "Mod": "approx",
+              "type": "timerange",
               "value": "22:00:00"
             }
           ]
@@ -10388,7 +10189,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-02T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "去年の前半",
@@ -10413,7 +10214,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "月曜日",
@@ -10442,10 +10243,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "今朝５時",
+        "Text": "今朝5時",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -10466,10 +10267,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１６年５月１日",
+        "Text": "2016年5月1日",
         "Start": 0,
         "End": 8,
         "TypeName": "datetimeV2.date",
@@ -10484,7 +10285,7 @@
         }
       },
       {
-        "Text": "２０１６年１２月１日またはその後",
+        "Text": "2016年12月1日またはその後",
         "Start": 12,
         "End": 27,
         "TypeName": "datetimeV2.daterange",
@@ -10495,7 +10296,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-12-01"
+              "start": "2016-12-01"
             }
           ]
         }
@@ -10507,10 +10308,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２年",
+        "Text": "2年",
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -10531,7 +10332,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後三時前",
@@ -10541,18 +10342,11 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T12:00",
+              "timex": "T15",
               "Mod": "before",
               "type": "timerange",
               "sourceEntity": "datetimepoint",
-              "end": "12:00:00"
-            },
-            {
-              "timex": "T00:00",
-              "Mod": "before",
-              "type": "timerange",
-              "sourceEntity": "datetimepoint",
-              "end": "00:00:00"
+              "end": "15:00:00"
             }
           ]
         }
@@ -10564,7 +10358,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二〇一八年十二月",
@@ -10585,16 +10379,16 @@
     ]
   },
   {
-    "Input": "「明日之后」は明日から発表します。",
+    "Input": "「明日之后」は明日発表されます。",
     "Context": {
       "ReferenceDateTime": "2019-08-28T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日",
-        "Start": 1,
-        "End": 2,
+        "Start": 7,
+        "End": 8,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -10613,7 +10407,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2013年及びその前",
@@ -10627,7 +10421,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "end": "2013-01-01"
+              "end": "2014-01-01"
             }
           ]
         }
@@ -10639,10 +10433,10 @@
     "Context": {
       "ReferenceDateTime": "2018-02-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２９日",
+        "Text": "29日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -10668,7 +10462,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の一時間",
@@ -10693,10 +10487,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年から",
+        "Text": "2018年から",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -10719,10 +10513,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "2016年９月１日から",
+        "Text": "2016年9月1日から",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -10733,13 +10527,13 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-09-01"
+              "start": "2016-09-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１６年１月１日前",
+        "Text": "2016年1月1日前",
         "Start": 14,
         "End": 23,
         "TypeName": "datetimeV2.daterange",
@@ -10762,10 +10556,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "平成１９年前",
+        "Text": "平成19年前",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -10788,10 +10582,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１９８７年１月１１日８時",
+        "Text": "1987年1月11日8時",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -10817,7 +10611,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-30T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "四月最後の月曜日から十月一日まで",
@@ -10842,10 +10636,10 @@
     "Context": {
       "ReferenceDateTime": "2018-01-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２９日",
+        "Text": "29日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -10871,10 +10665,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年８月６日またはその後",
+        "Text": "2019年8月6日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -10885,13 +10679,13 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-08-06"
+              "start": "2019-08-06"
             }
           ]
         }
       },
       {
-        "Text": "２０１９年１月１日",
+        "Text": "2019年1月1日",
         "Start": 19,
         "End": 27,
         "TypeName": "datetimeV2.date",
@@ -10912,10 +10706,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年１月１日またはその後",
+        "Text": "2010年1月1日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -10926,7 +10720,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
@@ -10938,10 +10732,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "夜７時半",
+        "Text": "夜7時半",
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -10962,7 +10756,7 @@
     "Context": {
       "ReferenceDateTime": "2016-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二十九日",
@@ -10991,10 +10785,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年０９月０９日以降",
+        "Text": "2019年09月09日以降",
         "Start": 0,
         "End": 12,
         "TypeName": "datetimeV2.daterange",
@@ -11011,7 +10805,7 @@
         }
       },
       {
-        "Text": "２０１９年０４月０４日またはその前",
+        "Text": "2019年04月04日またはその前",
         "Start": 17,
         "End": 33,
         "TypeName": "datetimeV2.daterange",
@@ -11022,7 +10816,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
@@ -11049,10 +10843,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年１０月１日朝９時２０分",
+        "Text": "2015年10月1日朝9時20分",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -11073,7 +10867,7 @@
     "Context": {
       "ReferenceDateTime": "2018-12-14T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "一時間",
@@ -11097,10 +10891,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年　１２月",
+        "Text": "2018年　12月",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -11122,7 +10916,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二〇一五年二月一日から",
@@ -11136,7 +10930,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -11148,10 +10942,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年２月１日またはその後",
+        "Text": "2015年2月1日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -11162,15 +10956,15 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１５年1月１日の前に",
+        "Text": "2015年1月1日の前",
         "Start": 18,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -11191,10 +10985,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日またはその前",
+        "Text": "2015年1月1日またはその前",
         "Start": 5,
         "End": 19,
         "TypeName": "datetimeV2.daterange",
@@ -11205,7 +10999,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
@@ -11217,7 +11011,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "十分前",
@@ -11227,7 +11021,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-08-30",
+              "timex": "2018-08-30T14:06:03",
               "type": "datetime",
               "value": "2018-08-30 14:06:03"
             }
@@ -11241,10 +11035,10 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１２時の後",
+        "Text": "12時の後",
         "Start": 0,
         "End": 4,
         "TypeName": "datetimeV2.timerange",
@@ -11274,7 +11068,7 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午前",
@@ -11299,10 +11093,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年の前半",
+        "Text": "2018年の前半",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -11324,7 +11118,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:13:33"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二分間前",
@@ -11334,7 +11128,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-08-30",
+              "timex": "2018-08-30T14:11:33",
               "type": "datetime",
               "value": "2018-08-30 14:11:33"
             }
@@ -11342,16 +11136,17 @@
         }
       },
       {
-        "Text": "三十分間",
-        "Start": 10,
+        "Text": "この三十分間",
+        "Start": 8,
         "End": 13,
-        "TypeName": "datetimeV2.duration",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "PT30M",
-              "type": "duration",
-              "value": "1800"
+              "timex": "(2018-08-30T13:43:33,2018-08-30T14:13:33,PT30M)",
+              "type": "datetimerange",
+              "start": "2018-08-30 13:43:33",
+              "end": "2018-08-30 14:13:33"
             }
           ]
         }
@@ -11363,7 +11158,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2010年1月10日またはその前",
@@ -11377,13 +11172,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
+              "end": "2010-01-10"
             }
           ]
         }
       },
       {
-        "Text": "２０１２年１月１日",
+        "Text": "2012年1月1日",
         "Start": 20,
         "End": 28,
         "TypeName": "datetimeV2.date",
@@ -11404,10 +11199,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年５月５日またはその前",
+        "Text": "2019年5月5日またはその前",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -11418,13 +11213,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-05-05"
+              "end": "2019-05-05"
             }
           ]
         }
       },
       {
-        "Text": "２０１９年１１月１１日",
+        "Text": "2019年11月11日",
         "Start": 19,
         "End": 29,
         "TypeName": "datetimeV2.date",
@@ -11445,10 +11240,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年１月１日またはその後",
+        "Text": "2019年1月1日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -11459,7 +11254,22 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-01-01"
+              "start": "2019-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2年",
+        "Start": 27,
+        "End": 28,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P2Y",
+              "type": "duration",
+              "value": "63072000"
             }
           ]
         }
@@ -11471,10 +11281,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "７月２５日朝ごろ",
+        "Text": "7月25日朝ごろ",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.datetimerange",
@@ -11482,12 +11292,14 @@
           "values": [
             {
               "timex": "XXXX-07-25TMO",
+              "Mod": "approx",
               "type": "datetimerange",
               "start": "2019-07-25 08:00:00",
               "end": "2019-07-25 12:00:00"
             },
             {
               "timex": "XXXX-07-25TMO",
+              "Mod": "approx",
               "type": "datetimerange",
               "start": "2020-07-25 08:00:00",
               "end": "2020-07-25 12:00:00"
@@ -11496,7 +11308,7 @@
         }
       },
       {
-        "Text": "７月２５日",
+        "Text": "7月25日",
         "Start": 9,
         "End": 13,
         "TypeName": "datetimeV2.date",
@@ -11516,7 +11328,7 @@
         }
       },
       {
-        "Text": "７月２５日朝",
+        "Text": "7月25日朝",
         "Start": 15,
         "End": 20,
         "TypeName": "datetimeV2.datetimerange",
@@ -11544,10 +11356,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年２月１日またはその前",
+        "Text": "2015年2月1日またはその前",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -11558,7 +11370,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -11570,10 +11382,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "毎週の月曜日夜８時",
+        "Text": "毎週の月曜日夜8時",
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -11594,7 +11406,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-30T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日",
@@ -11618,10 +11430,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "８月から来年の２月まで",
+        "Text": "8月から来年の2月まで",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -11643,10 +11455,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-02T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１７年の前半",
+        "Text": "2017年の前半",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -11668,10 +11480,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年１月４日またはその前",
+        "Text": "2010年1月4日またはその前",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -11682,13 +11494,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
       },
       {
-        "Text": "２０１２年１月１日後",
+        "Text": "2012年1月1日後",
         "Start": 19,
         "End": 28,
         "TypeName": "datetimeV2.daterange",
@@ -11696,10 +11508,10 @@
           "values": [
             {
               "timex": "2012-01-01",
-              "Mod": "since",
+              "Mod": "after",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "start": "2012-01-01"
             }
           ]
         }
@@ -11711,7 +11523,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "一月十日から十二日まで",
@@ -11738,16 +11550,16 @@
     ]
   },
   {
-    "Input": "毎年の前半は北京にいません。",
+    "Input": "年の前半は北京にいません。",
     "Context": {
       "ReferenceDateTime": "2019-09-02T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "毎年の前半",
+        "Text": "年の前半",
         "Start": 0,
-        "End": 4,
+        "End": 3,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -11767,7 +11579,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今夏",
@@ -11791,7 +11603,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後五時",
@@ -11799,7 +11611,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T17:00",
+              "timex": "T17",
               "type": "time",
               "value": "17:00:00"
             }
@@ -11815,22 +11627,17 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "今月１０日",
+        "Text": "今月10日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-03-10",
+              "timex": "2017-03-10",
               "type": "date",
               "value": "2017-03-10"
-            },
-            {
-              "timex": "XXXX-03-10",
-              "type": "date",
-              "value": "2018-03-10"
             }
           ]
         },
@@ -11844,27 +11651,27 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１３年０３月２２日またはその前",
+        "Text": "2013年03月22日またはその前",
         "Start": 0,
         "End": 16,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2011-03-22",
+              "timex": "2013-03-22",
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-03-22"
+              "end": "2013-03-22"
             }
           ]
         }
       },
       {
-        "Text": "２００９年０８月２９日またはその後",
+        "Text": "2009年08月29日またはその後",
         "Start": 18,
         "End": 34,
         "TypeName": "datetimeV2.daterange",
@@ -11872,7 +11679,7 @@
           "values": [
             {
               "timex": "2009-08-29",
-              "Mod": "after",
+              "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
               "start": "2009-08-29"
@@ -11887,7 +11694,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "後五分間",
@@ -11912,21 +11719,23 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "正月の３０日",
+        "Text": "正月の30日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "XXXX-01-30",
               "type": "date",
+              "isLunar": "True",
               "value": "2017-01-30"
             },
             {
               "timex": "XXXX-01-30",
               "type": "date",
+              "isLunar": "True",
               "value": "2018-01-30"
             }
           ]
@@ -11941,10 +11750,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "平成３０年１０月",
+        "Text": "平成30年10月",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -11966,10 +11775,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年６月１日から６月３０日まで",
+        "Text": "2019年6月1日から6月30日まで",
         "Start": 8,
         "End": 25,
         "TypeName": "datetimeV2.daterange",
@@ -11991,10 +11800,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日またはその後",
+        "Text": "2015年1月1日またはその後",
         "Start": 20,
         "End": 34,
         "TypeName": "datetimeV2.daterange",
@@ -12005,7 +11814,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -12017,10 +11826,10 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "午後３時前",
+        "Text": "午後3時前",
         "Start": 0,
         "End": 4,
         "TypeName": "datetimeV2.timerange",
@@ -12043,12 +11852,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "五日間",
+        "Text": "五日間前",
         "Start": 2,
-        "End": 4,
+        "End": 5,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -12067,7 +11876,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": []
   },
   {
@@ -12075,10 +11884,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年２月１日またはその前",
+        "Text": "2015年2月1日またはその前",
         "Start": 5,
         "End": 19,
         "TypeName": "datetimeV2.daterange",
@@ -12089,7 +11898,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -12097,16 +11906,16 @@
     ]
   },
   {
-    "Input": "２０１０年またはその後、２０１１年１月８日前のインタネット接続の平均単位",
+    "Input": "２０１０年１月１日またはその後、２０１１年１月８日前のインタネット接続の平均単位",
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年またはその後",
+        "Text": "2010年1月1日またはその後",
         "Start": 0,
-        "End": 10,
+        "End": 14,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -12115,15 +11924,15 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１１年１月８日前",
-        "Start": 12,
-        "End": 21,
+        "Text": "2011年1月8日前",
+        "Start": 16,
+        "End": 25,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -12144,7 +11953,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2018年12月",
@@ -12169,15 +11978,15 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "昨日午後２時から明日四時まで",
+        "Text": "昨日午後2時から明日四時まで",
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-06T14:00:00,2016-11-08T04:00:00,PT38H)",
+              "timex": "(2016-11-06T14,2016-11-08T04,PT38H)",
               "type": "datetimerange",
               "start": "2016-11-06 14:00:00",
               "end": "2016-11-08 04:00:00"
@@ -12194,7 +12003,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "来年",
@@ -12219,10 +12028,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年１１月１１日またはその前",
+        "Text": "2019年11月11日またはその前",
         "Start": 0,
         "End": 16,
         "TypeName": "datetimeV2.daterange",
@@ -12233,7 +12042,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-11"
+              "end": "2019-11-11"
             }
           ]
         }
@@ -12260,7 +12069,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "十二時後",
@@ -12270,14 +12079,14 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T12:00",
+              "timex": "T12",
               "Mod": "after",
               "type": "timerange",
               "sourceEntity": "datetimepoint",
               "start": "12:00:00"
             },
             {
-              "timex": "T00:00",
+              "timex": "T00",
               "Mod": "after",
               "type": "timerange",
               "sourceEntity": "datetimepoint",
@@ -12293,7 +12102,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": []
   },
   {
@@ -12301,10 +12110,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１２年１月１日とその前",
+        "Text": "2012年1月1日とその前",
         "Start": 0,
         "End": 12,
         "TypeName": "datetimeV2.daterange",
@@ -12315,13 +12124,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "end": "2012-01-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１０年１月１日後",
+        "Text": "2010年1月1日後",
         "Start": 16,
         "End": 25,
         "TypeName": "datetimeV2.daterange",
@@ -12344,15 +12153,15 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "午後５時１５分から６時まで",
+        "Text": "午後5時15分から6時まで",
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:15,T18,PT0H45M)",
+              "timex": "(T17:15,T18,PT45M)",
               "type": "timerange",
               "start": "17:15:00",
               "end": "18:00:00"
@@ -12369,15 +12178,36 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
-    "Results": []
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "12日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-XX-12",
+              "type": "date",
+              "value": "2017-03-12"
+            },
+            {
+              "timex": "XXXX-XX-12",
+              "type": "date",
+              "value": "2017-04-12"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
   },
   {
     "Input": "今年の後半は北京にいません。",
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今年の後半",
@@ -12402,7 +12232,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2004年8月15日",
@@ -12426,7 +12256,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-16T16:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今年",
@@ -12451,7 +12281,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-02T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "来年の後半",
@@ -12472,14 +12302,14 @@
     ]
   },
   {
-    "Input": "一月十日から廿日にまで",
+    "Input": "1月10日から20日まで",
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "一月十日から廿日にまで",
+        "Text": "1月10日から20日まで",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -12498,7 +12328,7 @@
           ]
         },
         "Start": 0,
-        "End": 10
+        "End": 11
       }
     ]
   },
@@ -12507,10 +12337,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年１１月９日またはその前",
+        "Text": "2019年11月9日またはその前",
         "Start": 0,
         "End": 15,
         "TypeName": "datetimeV2.daterange",
@@ -12521,7 +12351,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-09"
+              "end": "2019-11-09"
             }
           ]
         }
@@ -12533,10 +12363,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０月から１１月まで",
+        "Text": "10月から11月まで",
         "Start": 0,
         "End": 9,
         "TypeName": "datetimeV2.daterange",
@@ -12564,7 +12394,7 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後",
@@ -12589,7 +12419,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後二時",
@@ -12599,7 +12429,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T14:00",
+              "timex": "T14",
               "type": "time",
               "value": "14:00:00"
             }
@@ -12613,10 +12443,10 @@
     "Context": {
       "ReferenceDateTime": "2016-01-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２９日",
+        "Text": "29日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -12642,7 +12472,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "六日間",
@@ -12662,16 +12492,16 @@
     ]
   },
   {
-    "Input": "2010年1４日またはその前、または２０１１年１月７日の後のインタネット接続を位数の降順にランクする。",
+    "Input": "2010年1月４日またはその前、または２０１１年１月７日の後のインタネット接続を位数の降順にランクする。",
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "2010年1４日またはその前",
+        "Text": "2010年1月4日またはその前",
         "Start": 0,
-        "End": 13,
+        "End": 14,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -12680,15 +12510,15 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
       },
       {
-        "Text": "２０１１年１月７日の後",
-        "Start": 18,
-        "End": 28,
+        "Text": "2011年1月7日の後",
+        "Start": 19,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -12709,7 +12539,7 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "夜",
@@ -12719,10 +12549,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "TEV",
+              "timex": "TNI",
               "type": "timerange",
-              "start": "16:00:00",
-              "end": "20:00:00"
+              "start": "20:00:00",
+              "end": "23:59:59"
             }
           ]
         }
@@ -12734,7 +12564,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2015年1月1日またはその後",
@@ -12748,7 +12578,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -12760,12 +12590,12 @@
     "Context": {
       "ReferenceDateTime": "2019-08-28T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今日",
-        "Start": 1,
-        "End": 2,
+        "Start": 7,
+        "End": 8,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -12784,10 +12614,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "３月",
+        "Text": "3月",
         "Start": 5,
         "End": 6,
         "TypeName": "datetimeV2.daterange",
@@ -12809,7 +12639,7 @@
         }
       },
       {
-        "Text": "５月",
+        "Text": "5月",
         "Start": 19,
         "End": 20,
         "TypeName": "datetimeV2.daterange",
@@ -12837,10 +12667,10 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年前",
+        "Text": "2015年前",
         "Start": 0,
         "End": 5,
         "TypeName": "datetimeV2.daterange",
@@ -12863,7 +12693,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2010年1月29日",
@@ -12887,7 +12717,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎年",
@@ -12911,7 +12741,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "水曜日",
@@ -12940,7 +12770,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明後日",
@@ -12964,7 +12794,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後五時から六時まで",
@@ -12972,7 +12802,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:00,T18:00,PT1H)",
+              "timex": "(T17,T18,PT1H)",
               "type": "timerange",
               "start": "17:00:00",
               "end": "18:00:00"
@@ -12989,10 +12819,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０月の第1週",
+        "Text": "10月の第1週",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13005,8 +12835,8 @@
             {
               "timex": "XXXX-10-W01",
               "type": "daterange",
-              "start": "2017-09-25",
-              "end": "2017-10-02"
+              "start": "2017-10-02",
+              "end": "2017-10-09"
             }
           ]
         },
@@ -13020,7 +12850,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の半年",
@@ -13045,7 +12875,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "最近",
@@ -13069,10 +12899,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日前",
+        "Text": "2015年1月1日前",
         "Start": 0,
         "End": 9,
         "TypeName": "datetimeV2.daterange",
@@ -13089,7 +12919,7 @@
         }
       },
       {
-        "Text": "２０１５年２月１日またはその後",
+        "Text": "2015年2月1日またはその後",
         "Start": 13,
         "End": 27,
         "TypeName": "datetimeV2.daterange",
@@ -13100,7 +12930,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -13112,10 +12942,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年から",
+        "Text": "2015年から",
         "Start": 0,
         "End": 6,
         "TypeName": "datetimeV2.daterange",
@@ -13138,20 +12968,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１月１９日午後五時",
+        "Text": "1月19日午後五時",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-01-19T17:00",
+              "timex": "XXXX-01-19T17",
               "type": "datetime",
               "value": "2016-01-19 17:00:00"
             },
             {
-              "timex": "XXXX-01-19T17:00",
+              "timex": "XXXX-01-19T17",
               "type": "datetime",
               "value": "2017-01-19 17:00:00"
             }
@@ -13167,10 +12997,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-02T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１７年の後半",
+        "Text": "2017年の後半",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -13192,27 +13022,27 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年８月１日の後から",
+        "Text": "2018年8月1日の後から",
         "Start": 0,
         "End": 12,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2019-08-01",
+              "timex": "2018-08-01",
               "Mod": "after",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "start": "2019-08-01"
+              "start": "2018-08-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１９年４月５日前",
+        "Text": "2019年4月5日前",
         "Start": 17,
         "End": 26,
         "TypeName": "datetimeV2.daterange",
@@ -13220,10 +13050,10 @@
           "values": [
             {
               "timex": "2019-04-05",
-              "Mod": "until",
+              "Mod": "before",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "end": "2019-04-05"
             }
           ]
         }
@@ -13235,27 +13065,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年２月１日まで",
-        "Start": 16,
-        "End": 26,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2015-02-01",
-              "Mod": "until",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "２０１５年1月１日後",
+        "Text": "2015年1月1日後",
         "Start": 4,
         "End": 13,
         "TypeName": "datetimeV2.daterange",
@@ -13270,6 +13083,23 @@
             }
           ]
         }
+      },
+      {
+        "Text": "2015年2月1日まで",
+        "Start": 16,
+        "End": 26,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-02-01",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2015-02-01"
+            }
+          ]
+        }
       }
     ]
   },
@@ -13278,7 +13108,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "真夜中",
@@ -13289,11 +13119,6 @@
               "timex": "T00",
               "type": "time",
               "value": "00:00:00"
-            },
-            {
-              "timex": "T12",
-              "type": "time",
-              "value": "12:00:00"
             }
           ]
         },
@@ -13307,10 +13132,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日から",
+        "Text": "2015年1月1日から",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -13321,7 +13146,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -13333,7 +13158,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "後一年",
@@ -13358,10 +13183,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "朝２時半",
+        "Text": "朝2時半",
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -13382,7 +13207,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "七月二十五日朝",
@@ -13413,10 +13238,10 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１６年３月1日から",
+        "Text": "2016年3月1日から",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -13427,7 +13252,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-03-01"
+              "start": "2016-03-01"
             }
           ]
         }
@@ -13439,10 +13264,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１６年６月１日から６月３０日まで",
+        "Text": "2016年6月1日から6月30日まで",
         "Start": 0,
         "End": 17,
         "TypeName": "datetimeV2.daterange",
@@ -13464,10 +13289,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年２月１日またはその前",
+        "Text": "2015年2月1日またはその前",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -13478,7 +13303,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -13490,10 +13315,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１６年1月１０日から１２日まで",
+        "Text": "2016年1月10日から12日まで",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13515,10 +13340,10 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "今夜８時前",
+        "Text": "今夜8時前",
         "Start": 0,
         "End": 4,
         "TypeName": "datetimeV2.datetimerange",
@@ -13541,10 +13366,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００８年",
+        "Text": "2008年",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13566,7 +13391,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎日",
@@ -13590,10 +13415,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００７年後",
+        "Text": "2007年後",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13616,10 +13441,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日から",
+        "Text": "2015年1月1日から",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -13630,7 +13455,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -13642,7 +13467,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週の月曜日",
@@ -13666,7 +13491,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日午後五時",
@@ -13674,7 +13499,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-11-08T17:00",
+              "timex": "2016-11-08T17",
               "type": "datetime",
               "value": "2016-11-08 17:00:00"
             }
@@ -13690,7 +13515,7 @@
     "Context": {
       "ReferenceDateTime": "2018-12-14T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "半月間",
@@ -13714,23 +13539,23 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０月から来年の５月まで",
+        "Text": "10月から来年の5月まで",
         "Start": 0,
         "End": 11,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-10-01,XXXX-05-01,P5M)",
+              "timex": "(XXXX-10-01,2019-05-01,PXXM)",
               "type": "daterange",
               "start": "2017-10-01",
-              "end": "2018-05-01"
+              "end": "2019-05-01"
             },
             {
-              "timex": "(XXXX-10-01,XXXX-05-01,P5M)",
+              "timex": "(XXXX-10-01,2019-05-01,PXXM)",
               "type": "daterange",
               "start": "2018-10-01",
               "end": "2019-05-01"
@@ -13745,10 +13570,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００９年９月１日またはその後",
+        "Text": "2009年9月1日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -13759,7 +13584,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-09-01"
+              "start": "2009-09-01"
             }
           ]
         }
@@ -13771,10 +13596,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００８年",
+        "Text": "2008年",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13796,17 +13621,17 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "５月から１０月まで",
+        "Text": "5月から10月まで",
         "Start": 0,
         "End": 8,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-10-01,P5M)",
+              "timex": "(XXXX-05-01,XXXX-10-01,P5M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-10-01"
@@ -13821,10 +13646,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１２年１月７日またはその前",
+        "Text": "2012年1月7日またはその前",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -13835,7 +13660,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-07"
+              "end": "2012-01-07"
             }
           ]
         }
@@ -13847,10 +13672,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００１年１０月１日及びその前",
+        "Text": "2001年10月1日及びその前",
         "Start": 22,
         "End": 36,
         "TypeName": "datetimeV2.daterange",
@@ -13861,7 +13686,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2001-10-01"
+              "end": "2001-10-01"
             }
           ]
         }
@@ -13873,10 +13698,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年７月２５日朝",
+        "Text": "2019年7月25日朝",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.datetimerange",
@@ -13898,7 +13723,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今週の後半",
@@ -13923,10 +13748,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０月１２日、月曜日",
+        "Text": "10月12日,月曜日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -13952,7 +13777,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "夜十一時半十秒",
@@ -13976,7 +13801,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二十九日",
@@ -14005,7 +13830,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週",
@@ -14029,7 +13854,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎月",
@@ -14053,10 +13878,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日またはその前",
+        "Text": "2015年1月1日またはその前",
         "Start": 4,
         "End": 18,
         "TypeName": "datetimeV2.daterange",
@@ -14067,13 +13892,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
       },
       {
-        "Text": "２０１５年２月１日前",
+        "Text": "2015年2月1日前",
         "Start": 23,
         "End": 32,
         "TypeName": "datetimeV2.daterange",
@@ -14096,10 +13921,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "朝５時から６時まで",
+        "Text": "朝5時から6時まで",
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -14121,7 +13946,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "午後五時から夜七時半まで",
@@ -14146,7 +13971,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "朝八時",
@@ -14156,7 +13981,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T08:00",
+              "timex": "T08",
               "type": "time",
               "value": "08:00:00"
             }
@@ -14170,10 +13995,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年１月４日またはその後",
+        "Text": "2010年1月4日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -14184,7 +14009,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "start": "2010-01-04"
             }
           ]
         }
@@ -14196,10 +14021,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１０月",
+        "Text": "10月",
         "Start": 0,
         "End": 2,
         "TypeName": "datetimeV2.daterange",
@@ -14221,7 +14046,7 @@
         }
       },
       {
-        "Text": "５月",
+        "Text": "5月",
         "Start": 4,
         "End": 5,
         "TypeName": "datetimeV2.daterange",
@@ -14249,10 +14074,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日またはその後",
+        "Text": "2015年1月1日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -14263,7 +14088,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -14275,10 +14100,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年1月１日",
+        "Text": "2015年1月1日",
         "Start": 0,
         "End": 8,
         "TypeName": "datetimeV2.date",
@@ -14293,7 +14118,7 @@
         }
       },
       {
-        "Text": "２０１５年２月１日から",
+        "Text": "2015年2月1日から",
         "Start": 12,
         "End": 22,
         "TypeName": "datetimeV2.daterange",
@@ -14304,7 +14129,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -14316,10 +14141,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年まで",
+        "Text": "2018年まで",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -14342,16 +14167,17 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "夜１０時ごろ",
+        "Text": "夜10時ごろ",
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T22",
-              "type": "time",
+              "Mod": "approx",
+              "type": "timerange",
               "value": "22:00:00"
             }
           ]
@@ -14366,7 +14192,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の朝",
@@ -14391,10 +14217,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１１年１月１０日またはその前",
+        "Text": "2011年1月10日またはその前",
         "Start": 0,
         "End": 15,
         "TypeName": "datetimeV2.daterange",
@@ -14405,7 +14231,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-01-10"
+              "end": "2011-01-10"
             }
           ]
         }
@@ -14417,10 +14243,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年後",
+        "Text": "2018年後",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -14443,10 +14269,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年８月１日から",
+        "Text": "2019年8月1日から",
         "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
@@ -14454,7 +14280,7 @@
           "values": [
             {
               "timex": "2019-08-01",
-              "Mod": "after",
+              "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
               "start": "2019-08-01"
@@ -14463,18 +14289,18 @@
         }
       },
       {
-        "Text": "または２０１９年４月５日またはその後",
-        "Start": 12,
+        "Text": "2019年4月5日またはその後",
+        "Start": 15,
         "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2019-04-05",
-              "Mod": "until",
+              "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "start": "2019-04-05"
             }
           ]
         }
@@ -14486,7 +14312,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "三月から九月まで",
@@ -14496,7 +14322,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-03-01,2018-09-01,P6M)",
+              "timex": "(XXXX-03-01,XXXX-09-01,P6M)",
               "type": "daterange",
               "start": "2018-03-01",
               "end": "2018-09-01"
@@ -14511,7 +14337,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7週間",
@@ -14535,10 +14361,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "夜９時半",
+        "Text": "夜9時半",
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -14559,7 +14385,7 @@
     "Context": {
       "ReferenceDateTime": "2018-12-14T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "半年",
@@ -14583,16 +14409,17 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "旧暦の２０１５年１０月１日",
+        "Text": "旧暦の2015年10月1日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "2015-10-01",
               "type": "date",
+              "isLunar": "True",
               "value": "2015-10-01"
             }
           ]
@@ -14607,10 +14434,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１０年１月２９日夜六時",
+        "Text": "2010年1月29日夜六時",
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -14631,7 +14458,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "零時",
@@ -14642,11 +14469,6 @@
               "timex": "T00",
               "type": "time",
               "value": "00:00:00"
-            },
-            {
-              "timex": "T12",
-              "type": "time",
-              "value": "12:00:00"
             }
           ]
         },
@@ -14660,10 +14482,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２００９年",
+        "Text": "2009年",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -14685,10 +14507,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年１２月は０月ではありません。",
+        "Text": "2018年12月",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -14701,7 +14523,7 @@
           ]
         },
         "Start": 0,
-        "End": 18
+        "End": 7
       }
     ]
   },
@@ -14710,7 +14532,7 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "八時",
@@ -14720,12 +14542,12 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T08:00",
+              "timex": "T08",
               "type": "time",
               "value": "08:00:00"
             },
             {
-              "timex": "T20:00",
+              "timex": "T20",
               "type": "time",
               "value": "20:00:00"
             }
@@ -14739,10 +14561,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１８年十月一日から１９年二月三日まで",
+        "Text": "2018年十月一日から19年二月三日まで",
         "Start": 0,
         "End": 19,
         "TypeName": "datetimeV2.daterange",
@@ -14764,10 +14586,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年９月１４日またはその前",
+        "Text": "2019年9月14日またはその前",
         "Start": 4,
         "End": 19,
         "TypeName": "datetimeV2.daterange",
@@ -14778,7 +14600,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-09-14"
+              "end": "2019-09-14"
             }
           ]
         }
@@ -14790,10 +14612,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１４年６月４日またはその後",
+        "Text": "2014年6月4日またはその後",
         "Start": 0,
         "End": 14,
         "TypeName": "datetimeV2.daterange",
@@ -14804,13 +14626,13 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-04"
+              "start": "2014-06-04"
             }
           ]
         }
       },
       {
-        "Text": "２００９年８月１６日またはその後",
+        "Text": "2009年8月16日またはその後",
         "Start": 16,
         "End": 31,
         "TypeName": "datetimeV2.daterange",
@@ -14818,10 +14640,10 @@
           "values": [
             {
               "timex": "2009-08-16",
-              "Mod": "until",
+              "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-08-16"
+              "start": "2009-08-16"
             }
           ]
         }
@@ -14833,7 +14655,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "五時間",
@@ -14857,10 +14679,10 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１９年０４月０４日またはその前",
+        "Text": "2019年04月04日またはその前",
         "Start": 0,
         "End": 16,
         "TypeName": "datetimeV2.daterange",
@@ -14871,13 +14693,13 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
       },
       {
-        "Text": "２０１９年０９月０９日以降",
+        "Text": "2019年09月09日以降",
         "Start": 21,
         "End": 33,
         "TypeName": "datetimeV2.daterange",
@@ -14915,7 +14737,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "二時間後",
@@ -14925,7 +14747,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-08-30",
+              "timex": "2018-08-30T16:16:03",
               "type": "datetime",
               "value": "2018-08-30 16:16:03"
             }
@@ -14939,18 +14761,24 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "昨日５時から６時まで",
+        "Text": "昨日5時から6時まで",
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-06T05:00,2016-11-06T06:00,PT1H)",
+              "timex": "(2016-11-06T05,2016-11-06T06,PT1H)",
               "type": "datetimerange",
               "start": "2016-11-06 05:00:00",
               "end": "2016-11-06 06:00:00"
+            },
+            {
+              "timex": "(2016-11-06T17,2016-11-06T18,PT1H)",
+              "type": "datetimerange",
+              "start": "2016-11-06 17:00:00",
+              "end": "2016-11-06 18:00:00"
             }
           ]
         },
@@ -14964,10 +14792,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年",
+        "Text": "2015年",
         "Start": 5,
         "End": 9,
         "TypeName": "datetimeV2.daterange",
@@ -14983,7 +14811,7 @@
         }
       },
       {
-        "Text": "２０１８年",
+        "Text": "2018年",
         "Start": 21,
         "End": 25,
         "TypeName": "datetimeV2.daterange",
@@ -15005,10 +14833,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１月１５日４時から２月３日９時までの間",
+        "Text": "1月15日4時から2月3日9時までの間",
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -15030,10 +14858,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "１９９５年から１９９７年まで",
+        "Text": "1995年から1997年まで",
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -15051,23 +14879,23 @@
     ]
   },
   {
-    "Input": "ご飯は後三十分にできます。",
+    "Input": "ご飯は後三十分でできます。",
     "Context": {
       "ReferenceDateTime": "2018-12-14T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "三十分",
+        "Text": "三十分で",
         "Start": 4,
-        "End": 6,
-        "TypeName": "datetimeV2.duration",
+        "End": 7,
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "PT0.5H",
-              "type": "duration",
-              "value": "1800"
+              "timex": "2018-12-14T12:30:00",
+              "type": "datetime",
+              "value": "2018-12-14 12:30:00"
             }
           ]
         }
@@ -15079,10 +14907,10 @@
     "Context": {
       "ReferenceDateTime": "2018-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "２０１５年から２０１８年までの間",
+        "Text": "2015年から2018年までの間",
         "Start": 5,
         "End": 20,
         "TypeName": "datetimeV2.daterange",
@@ -15104,7 +14932,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2014年6月14日から",
@@ -15118,24 +14946,24 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-14"
+              "start": "2014-06-14"
             }
           ]
         }
       },
       {
-        "Text": "2014年9月14日０時の前",
+        "Text": "2014年9月14日0時の前",
         "Start": 25,
         "End": 38,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2014-09-14",
+              "timex": "2014-09-14T00",
               "Mod": "before",
-              "type": "daterange",
+              "type": "datetimerange",
               "sourceEntity": "datetimepoint",
-              "end": "2014-09-14"
+              "end": "2014-09-14 00:00:00"
             }
           ]
         }
@@ -15147,7 +14975,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15176,7 +15004,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15205,7 +15033,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15234,7 +15062,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "30/2",
@@ -15258,7 +15086,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2/2019",
@@ -15282,7 +15110,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2/2020",
@@ -15302,14 +15130,14 @@
     ]
   },
   {
-    "Input": "28/2-1/3",
+    "Input": "2/28-3/1",
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "28/2-1/3",
+        "Text": "2/28-3/1",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -15333,14 +15161,14 @@
     ]
   },
   {
-    "Input": "29/2-1/3",
+    "Input": "2/29-3/1",
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "29/2-1/3",
+        "Text": "2/29-3/1",
         "Start": 0,
         "End": 7,
         "TypeName": "datetimeV2.daterange",
@@ -15368,7 +15196,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2-1/3/2019",
@@ -15392,7 +15220,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-	"NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -15418,7 +15245,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "平成13年",
@@ -15443,7 +15270,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "平成二年",
@@ -15468,7 +15295,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "平成元年",
@@ -15493,7 +15320,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昭和13年",
@@ -15518,7 +15345,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昭和二年",
@@ -15543,7 +15370,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昭和元年",
@@ -15568,7 +15395,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "大正13年",
@@ -15593,7 +15420,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "大正二年",
@@ -15618,7 +15445,7 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "大正元年",
@@ -15643,12 +15470,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明治13年",
-        "Start": 18,
-        "End": 26,
+        "Start": 0,
+        "End": 4,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -15668,12 +15495,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明治二年",
-        "Start": 18,
-        "End": 26,
+        "Start": 0,
+        "End": 3,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -15693,12 +15520,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明治元年",
-        "Start": 18,
-        "End": 26,
+        "Start": 0,
+        "End": 3,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -15718,10 +15545,10 @@
     "Context": {
       "ReferenceDateTime": "2019-09-03T08:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "６月１５日の朝",
+        "Text": "6月15日の朝",
         "Start": 6,
         "End": 12,
         "TypeName": "datetimeV2.datetimerange",
@@ -15749,10 +15576,10 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "旧暦の２０１５年お正月の１日",
+        "Text": "旧暦の2015年お正月の1日",
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -15773,7 +15600,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-12T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "元旦",
@@ -15783,7 +15610,12 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2020-01-01",
+              "timex": "XXXX-01-01",
+              "type": "date",
+              "value": "2019-01-01"
+            },
+            {
+              "timex": "XXXX-01-01",
               "type": "date",
               "value": "2020-01-01"
             }
@@ -15797,7 +15629,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-12T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "大晦日",
@@ -15807,7 +15639,12 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-12-31",
+              "timex": "XXXX-12-31",
+              "type": "date",
+              "value": "2018-12-31"
+            },
+            {
+              "timex": "XXXX-12-31",
               "type": "date",
               "value": "2019-12-31"
             }
@@ -15853,6 +15690,397 @@
               "type": "daterange",
               "sourceEntity": "datetimerange",
               "end": "2000-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "32-2015、これは有効な日付ですか。",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "第一シーズンの日付は2014年6月14日からまたは2014年9月14日の前、Xは-83.8232以下の街",
+    "Context": {
+      "ReferenceDateTime": "2019-01-06T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2014年6月14日から",
+        "Start": 10,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014-06-14",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "start": "2014-06-14"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2014年9月14日の前",
+        "Start": 25,
+        "End": 36,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014-09-14",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2014-09-14"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "食事の準備には三十分かかります",
+    "Context": {
+      "ReferenceDateTime": "2018-12-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "三十分",
+        "Start": 7,
+        "End": 9,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT30M",
+              "type": "duration",
+              "value": "1800"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "１２番目",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "12:00前",
+    "Context": {
+      "ReferenceDateTime": "2019-07-01T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "12:00前",
+        "Start": 0,
+        "End": 5,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T12:00",
+              "Mod": "before",
+              "type": "timerange",
+              "sourceEntity": "datetimepoint",
+              "end": "12:00:00"
+            },
+            {
+              "timex": "T00:00",
+              "Mod": "before",
+              "type": "timerange",
+              "sourceEntity": "datetimepoint",
+              "end": "00:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "午前5時から6時",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "午前5時から6時",
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T05,T06,PT1H)",
+              "type": "timerange",
+              "start": "05:00:00",
+              "end": "06:00:00"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "私は月の前半は北京にいません",
+    "Context": {
+      "ReferenceDateTime": "2019-09-03T08:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "月の前半",
+        "Start": 2,
+        "End": 5,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-09-01,2019-09-16,P15D)",
+              "type": "daterange",
+              "start": "2019-09-01",
+              "end": "2019-09-16"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2010-01-10またはそれ以降および2011-01-07以前を含め、どのような種類のネットワーク接続がユニットの中央値を超えないのですか？",
+    "Context": {
+      "ReferenceDateTime": "2019-01-06T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2010-01-10またはそれ以降",
+        "Start": 0,
+        "End": 16,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2010-01-10",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "start": "2010-01-10"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2011-01-07以前",
+        "Start": 20,
+        "End": 31,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2011-01-07",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2011-01-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "日曜日の終わり",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "日曜日の終わり",
+        "Start": 0,
+        "End": 6,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-7T23:59:59",
+              "type": "datetime",
+              "value": "2016-11-06 23:59:59"
+            },
+            {
+              "timex": "XXXX-WXX-7T23:59:59",
+              "type": "datetime",
+              "value": "2016-11-13 23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "日付は2016年8月5日であるべきです。",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2016年8月5日",
+        "Start": 3,
+        "End": 11,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-08-05",
+              "type": "date",
+              "value": "2016-08-05"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "１０月から５月までの間のデータをいただけますか？",
+    "Context": {
+      "ReferenceDateTime": "2018-09-18T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "10月から5月まで",
+        "Start": 0,
+        "End": 8,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-10-01,XXXX-05-01,P7M)",
+              "type": "daterange",
+              "start": "2017-10-01",
+              "end": "2018-05-01"
+            },
+            {
+              "timex": "(XXXX-10-01,XXXX-05-01,P7M)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2019-05-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "１０月から来年の５月までの間のデータをいただけますか？",
+    "Context": {
+      "ReferenceDateTime": "2018-11-18T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "10月から来年の5月まで",
+        "Start": 0,
+        "End": 11,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2019-05-01,P7M)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2019-05-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "今週の日曜日の終わりに戻ります。",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "今週の日曜日の終わり",
+        "Start": 0,
+        "End": 9,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-13T23:59:59",
+              "type": "datetime",
+              "value": "2016-11-13 23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2019/2/28-2019/3/1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2019/2/28-2019/3/1",
+        "Start": 0,
+        "End": 17,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-28,2019-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2020/2/29-2020/3/1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2020/2/29-2020/3/1",
+        "Start": 0,
+        "End": 17,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-02-29,2020-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
             }
           ]
         }

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -984,21 +984,19 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1時間で",
         "Start": 0,
         "End": 3,
-        "TypeName": "datetimeV2.datetimerange",
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
-              "type": "datetimerange",
-              "start": "2016-11-07 16:12:00",
-              "end": "2016-11-07 17:12:00"
+              "timex": "2016-11-07T17:12:00",
+              "type": "datetime",
+              "value": "2016-11-07 17:12:00"
             }
           ]
         }
@@ -2708,7 +2706,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-25T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2832,7 +2829,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2853,18 +2849,6 @@
               "type": "datetimerange",
               "start": "2018-05-21 11:00:00",
               "end": "2018-05-21 16:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-14 23:00:00",
-              "end": "2018-05-15 04:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-21 23:00:00",
-              "end": "2018-05-22 04:00:00"
             }
           ]
         }
@@ -3121,20 +3105,19 @@
     "Context": {
       "ReferenceDateTime": "2018-05-22T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "一日",
         "Start": 2,
         "End": 3,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-05-22",
-              "type": "date",
-              "value": "2018-05-22"
+              "timex": "P1D",
+              "type": "duration",
+              "value": "86400"
             }
           ]
         }
@@ -3171,7 +3154,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3224,7 +3206,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3994,7 +3975,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4024,11 +4004,10 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の金曜日（6月15日）",
+        "Text": "今週の金曜日(6月15日)",
         "Start": 5,
         "End": 17,
         "TypeName": "datetimeV2.date",
@@ -4062,7 +4041,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4229,7 +4207,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4316,17 +4293,16 @@
         }
       },
       {
-        "Text": "泊",
-        "Start": 7,
+        "Text": "2泊",
+        "Start": 6,
         "End": 7,
-        "TypeName": "datetimeV2.timerange",
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "TNI",
-              "type": "timerange",
-              "start": "20:00:00",
-              "end": "23:59:59"
+              "timex": "P2D",
+              "type": "duration",
+              "value": "172800"
             }
           ]
         }
@@ -4473,13 +4449,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今日の午後4時前に",
+        "Text": "今日の午後4時前",
         "Start": 3,
-        "End": 11,
+        "End": 10,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4487,7 +4462,7 @@
               "timex": "2018-06-26T16",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
+              "sourceEntity": "datetimepoint",
               "end": "2018-06-26 16:00:00"
             }
           ]
@@ -4526,7 +4501,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4540,7 +4514,6 @@
               "timex": "2018-06-19T14",
               "Mod": "before",
               "type": "datetimerange",
-              "sourceEntity": "datetimerange",
               "end": "2018-06-19 14:00:00"
             }
           ]
@@ -5157,15 +5130,14 @@
     ]
   },
   {
-    "Input": "2時間以内あるいは4日以上続く記録で、30分以上のものを検索して。",
+    "Input": "2時間以下あるいは4日以上続く記録で、30分以上のものを検索して。",
     "Context": {
       "ReferenceDateTime": "2018-07-09T22:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2時間以内",
+        "Text": "2時間以下",
         "Start": 0,
         "End": 4,
         "TypeName": "datetimeV2.duration",
@@ -5205,7 +5177,7 @@
           "values": [
             {
               "timex": "PT30M",
-              "Mod": "less",
+              "Mod": "more",
               "type": "duration",
               "value": "1800"
             }
@@ -5452,7 +5424,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-30T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5493,18 +5464,6 @@
               "type": "datetimerange",
               "start": "2018-08-01 10:00:00",
               "end": "2018-08-01 16:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-3T22,XXXX-WXX-4T04,PT6H)",
-              "type": "datetimerange",
-              "start": "2018-07-25 22:00:00",
-              "end": "2018-07-26 04:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-3T22,XXXX-WXX-4T04,PT6H)",
-              "type": "datetimerange",
-              "start": "2018-08-01 22:00:00",
-              "end": "2018-08-02 04:00:00"
             }
           ]
         }
@@ -5984,7 +5943,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6004,18 +5962,16 @@
         }
       },
       {
-        "Text": "早朝午前7時に",
+        "Text": "早朝午前7時",
         "Start": 2,
-        "End": 8,
-        "TypeName": "datetimeV2.timerange",
+        "End": 7,
+        "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
-              "Mod": "since",
-              "type": "timerange",
-              "sourceEntity": "datetimerange",
-              "start": "07:00:00"
+              "timex": "T07",
+              "type": "time",
+              "value": "07:00:00"
             }
           ]
         }
@@ -6129,22 +6085,19 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4営業日前",
         "Start": 5,
         "End": 9,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-15,2018-08-21,P4BD)",
-              "type": "daterange",
-              "list": "2018-08-15,2018-08-16,2018-08-17,2018-08-20",
-              "start": "2018-08-15",
-              "end": "2018-08-21"
+              "timex": "2018-08-15",
+              "type": "date",
+              "value": "2018-08-15"
             }
           ]
         }
@@ -8879,7 +8832,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8890,14 +8842,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-1",
+              "timex": "2019-01-21",
               "type": "date",
               "value": "2019-01-21"
-            },
-            {
-              "timex": "XXXX-WXX-1",
-              "type": "date",
-              "value": "2019-10-21"
             }
           ]
         }
@@ -9442,9 +9389,9 @@
         }
       },
       {
-        "Text": "木曜日の19時から21時で",
+        "Text": "木曜日の19時から21時",
         "Start": 12,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -15658,7 +15605,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -15679,8 +15625,8 @@
       },
       {
         "Text": "2000年以前",
-        "Start": 14,
-        "End": 20,
+        "Start": 15,
+        "End": 21,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -16082,6 +16028,174 @@
               "type": "daterange",
               "start": "2020-02-29",
               "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "次の1時間で戻ります。",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "次の1時間",
+        "Start": 0,
+        "End": 4,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 17:12:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "コルタナ、過去4営業日何か設定してくれませんか",
+    "Context": {
+      "ReferenceDateTime": "2018-08-21T10:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "過去4営業日",
+        "Start": 5,
+        "End": 10,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-08-15,2018-08-21,P4BD)",
+              "type": "daterange",
+              "list": "2018-08-15,2018-08-16,2018-08-17,2018-08-20",
+              "start": "2018-08-15",
+              "end": "2018-08-21"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "この日はブロックされています",
+    "Context": {
+      "ReferenceDateTime": "2018-05-22T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "この日",
+        "Start": 0,
+        "End": 2,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-22",
+              "type": "date",
+              "value": "2018-05-22"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "コルタナ、2営業日以内にSkype通話を設定してください。",
+    "Context": {
+      "ReferenceDateTime": "2018-04-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2営業日以内に",
+        "Start": 5,
+        "End": 11,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-04-08,2018-04-10,P2BD)",
+              "type": "daterange",
+              "list": "2018-04-09,2018-04-10",
+              "start": "2018-04-08",
+              "end": "2018-04-10"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "コルタナ、4営業日以内にSkypeコールをセットしてください。",
+    "Context": {
+      "ReferenceDateTime": "2018-04-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4営業日以内に",
+        "Start": 5,
+        "End": 11,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-04-08,2018-04-12,P4BD)",
+              "type": "daterange",
+              "list": "2018-04-09,2018-04-10,2018-04-11,2018-04-12",
+              "start": "2018-04-08",
+              "end": "2018-04-12"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "4日を上回る1週間を下回る記録を表示して。",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4日を上回る",
+        "Start": 0,
+        "End": 5,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P4D",
+              "Mod": "more",
+              "type": "duration",
+              "value": "345600"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "1週間を下回る",
+        "Start": 6,
+        "End": 12,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1W",
+              "Mod": "less",
+              "type": "duration",
+              "value": "604800"
             }
           ]
         }

--- a/Specs/DateTime/Japanese/DateTimeParser.json
+++ b/Specs/DateTime/Japanese/DateTimeParser.json
@@ -1306,7 +1306,7 @@
         "Text": "5時間で",
         "Type": "datetime",
         "Value": {
-          "Timex": "2016-11-07T05",
+          "Timex": "2016-11-07T05:00:00",
           "FutureResolution": {
             "dateTime": "2016-11-07 05:00:00"
           },
@@ -1642,7 +1642,7 @@
         "Text": "あと1時間",
         "Type": "datetime",
         "Value": {
-          "Timex": "2017-11-23T01",
+          "Timex": "2017-11-23T01:00:00",
           "FutureResolution": {
             "dateTime": "2017-11-23 01:00:00"
           },
@@ -1667,7 +1667,7 @@
         "Type": "datetime",
         "Value": {
           "Mod": "less",
-          "Timex": "2017-11-23T01",
+          "Timex": "2017-11-23T01:00:00",
           "FutureResolution": {
             "dateTime": "2017-11-23 01:00:00"
           },

--- a/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
@@ -624,18 +624,6 @@
     ]
   },
   {
-    "Input": "それは今日の午後4時前に起きるでしょう。",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "今日の午後4時前",
-        "Type": "datetimerange",
-        "Start": 3,
-        "Length": 8
-      }
-    ]
-  },
-  {
     "Input": "それは前の火曜日の午後2時までに起きた。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [

--- a/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
@@ -624,18 +624,6 @@
     ]
   },
   {
-    "Input": "それは2015年1月1日の2時以降に起きるでしょう。",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "2015年1月1日の2時以降",
-        "Type": "datetimerange",
-        "Start": 3,
-        "Length": 14
-      }
-    ]
-  },
-  {
     "Input": "それは今日の午後4時前に起きるでしょう。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -648,18 +636,6 @@
     ]
   },
   {
-    "Input": "それは来週の水曜日の午前10時以降に起きるでしょう。",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "来週の水曜日の午前10時以降",
-        "Type": "datetimerange",
-        "Start": 3,
-        "Length": 14
-      }
-    ]
-  },
-  {
     "Input": "それは前の火曜日の午後2時までに起きた。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -668,18 +644,6 @@
         "Type": "datetimerange",
         "Start": 3,
         "Length": 12
-      }
-    ]
-  },
-  {
-    "Input": "2月1日の6時までには行きましょう。",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "2月1日の6時まで",
-        "Type": "datetimerange",
-        "Start": 0,
-        "Length": 9
       }
     ]
   },

--- a/Specs/DateTime/Japanese/SetExtractor.json
+++ b/Specs/DateTime/Japanese/SetExtractor.json
@@ -216,18 +216,6 @@
     ]
   },
   {
-    "Input": "5月9日から2泊予約できますか。",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "泊",
-        "Type": "set",
-        "Start": 7,
-        "Length": 1
-      }
-    ]
-  },
-  {
     "Input": "毎週日曜日午後八時に事件が起こる",
     "NotSupported": "javascript, python, java",
     "Results": [

--- a/Specs/DateTime/Japanese/TimeExtractor.json
+++ b/Specs/DateTime/Japanese/TimeExtractor.json
@@ -352,10 +352,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "正午ごろ",
+        "Text": "正午",
         "Type": "time",
         "Start": 0,
-        "Length": 4
+        "Length": 2
       }
     ]
   },
@@ -388,10 +388,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "11時ごろ",
+        "Text": "11時",
         "Type": "time",
         "Start": 0,
-        "Length": 5
+        "Length": 3
       }
     ]
   },
@@ -448,10 +448,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午後3時ごろ",
+        "Text": "午後3時",
         "Type": "time",
         "Start": 0,
-        "Length": 6
+        "Length": 4
       }
     ]
   },

--- a/Specs/DateTime/Japanese/TimeParser.json
+++ b/Specs/DateTime/Japanese/TimeParser.json
@@ -697,7 +697,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "正午ごろ",
+        "Text": "正午",
         "Type": "time",
         "Value": {
           "Timex": "T12",
@@ -709,7 +709,7 @@
           }
         },
         "Start": 0,
-        "Length": 4
+        "Length": 2
       }
     ]
   },
@@ -739,7 +739,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "11時ごろ",
+        "Text": "11時",
         "Type": "time",
         "Value": {
           "Timex": "T11",
@@ -751,7 +751,7 @@
           }
         },
         "Start": 0,
-        "Length": 5
+        "Length": 3
       }
     ]
   },
@@ -844,7 +844,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午後3時ごろ",
+        "Text": "午後3時",
         "Type": "time",
         "Value": {
           "Timex": "T15",
@@ -856,7 +856,7 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 4
       }
     ]
   },


### PR DESCRIPTION
559 pass, 19 fail.

Modified test cases:

**In Chinese:**

- Fixed Parsing of patterns like "10th of this month":
     - "本月十日" (10th of this month) (in DateParser and Model)
- Fixed parsing of 'ampm' cases:
     - "从昨天5:00-6:00" (From 5:00-6:00 yesterday), "5:00到6:00" (5:00 to 6:00) added pm resolution (Model)
     - "零点", "零点整" (midnight) removed T12 resolution (Model)


**In Japanese:**

**DateParser:**
- Fixed Parsing of patterns referring to "this/next month"
     - "今月の27日" (27th of this month)
     - "今月27日" (27th of this month)
     - "来月の二十日" (20th of next month)
     - "今月の三十一日" (31st of this month)
     - "次の月の20日" (20th of the next month)
     - "今月の十日" (10th of this month)


**DateTimeExtractor:**
- Removed extraction of 'around' modifier "ごろ"
     - "明日の午前8時ごろ" -> "明日の午前8時" (Around 8 am tomorrow)
     - "今夜7時ごろ" -> "今夜7時" (Around 7 o'clock tonight)
- "日曜日のうちに戻ります。" (I'll be back on Sunday.), removed extraction of 'sunday'. Added new case "日曜日の終わりに帰ります" (I'll be back at the end of Sunday) where "日曜日の終わり" (end of sunday) is extracted


**DateTimePeriodExtractor:**
- Removed following test cases because in the corresponding English cases the modifiers occur between the date and time entities but in Japanese such construction is not used. The cases are correctly processed in DateTimeModel.
     - "それは2015年1月1日の2時以降に起きるでしょう。" (It will happen after 2 o'clock on January 1, 2015.)
     - "それは来週の水曜日の午前10時以降に起きるでしょう。" (It will happen after 10 am next Wednesday.)
     - "それは前の火曜日の午後2時までに起きた。" (It happened by 2 pm last Tuesday.)


**SetExtractor:**
- Removed test case "5月9日から2泊予約できますか。" (Can I book for 2 nights from May 9th?). Japanese does not use plurals so expressions like "nights", "mondays"... are not supported in Set


**TimeExtractor/TimeParser:**
- Removed extraction of 'around' modifier "ごろ"
     - "正午ごろ" -> "正午" (Around noon)
     - "11時ごろ" -> "11時" (Around 11 o'clock)
     - "午後3時ごろ" -> "午後3時" (Around 3 pm)


**DateTimeModel:**
- "日曜日のうちに戻ります。", "今週の日曜日のうちに" expect datetime but resolve to date because they refer to "Sunday." instead of "end of Sunday". Added new cases "日曜日の終わり", "今週の日曜日の終わりに戻ります。" which resolve correctly.
- "来週の月曜日午前9時から午後1時に会議の予定を入れて。" (Schedule a meeting next Monday from 9am to 1pm.), modified resolution from datetime to datetimerange
- "トムと私は2週間以内に会議をしますので、2週間以内に会議の予定を入れるようご協力をお願いします。" (Tom and I will have a meeting within 2 weeks, so please help me schedule a meeting within 2 weeks.), modified resolution from date to daterange due to the use of "within" instead of "in"
- "今日の昼頃北京に出発します。" updated resolution because it translates to "I'm leaving for Beijing around midday today." instead of "I'll leave for Beijing mid today." 
- "今日から3分後に始めましょう。" updated resolution because it translates literally to "Let's get started in 3 minutes from today" instead of "Let's start 3 minutes from today" and so the entity is datetime instead of duration.
- "これから数週間のうちにそれを手配しましょう。よろしいですか。" updated resolution because "これから数週間" means "next few weeks" instead of "next couple of weeks" 
- "5分後に何が起こるでしょうか。" updated resolution because translates to "What will happen in 5 minutes?" instead of "What will happen in the 5 coming minutes?"
- "2016年1月1日の午後6時以降にしか出発できません。" updated resolution because it translates to "You can only depart after 6 pm on January 1, 2016." instead "I can only leave on 1/1/2016 and after 6PM"
- "彼は2日で戻ってくるでしょうか。 それとも一週間？" updated resolution because it translates to "Will he be back in two days or a week?" instead of "Will he be back in two days? or in a week?"
- "すべてのディスクが今週末更新されるので、コードを入れ忘れないでください。" updated resolution because it translates to "Don't forget to enter the code as all discs will be updated this weekend." instead of "Don't forget to push your code as all the disks will be renewed the end of the week."
- "先週の水曜日、あなたはどこにいましたか。"  updated resolution because it translates to "Where were you last Wednesday?" instead of "Where were you on this past Wednesday?"
- "12日の7時30分から9時30分の間、あなたはどこにいましたか。" updated resolution from timerange to datetimerange because "12日" unambiguously indicates a day in Japanese
- "2015年32、これは有効な日付ですか。" "2015年" is extracted because "年" unambiguously indicates a year
- "２０１０年１月１０日から２０１２年１月７日の前まで、単位は中間値に超さないインタネット接続はどれですか？" returns a single extraction because it translates to ""Which internet connection does the unit not exceed the median from January 10, 2010 to January 7, 2012?" instead of "Including 2010-01-10 and later and before 2011-01-07, what kind of network connection does not exceed the median of the unit?" (translated from corresponding Chinese case). New test cases added which return the expected extractions "2010-01-10またはそれ以降および2011-01-07以前を含め、どのような種類のネットワーク接続がユニットの中央値を超えないのですか？"
- "今月の半ばまでは北京にいません。" updated resolution because translates to "I will not be in Beijing until the middle of this month." instead of "I'm not in Beijing in the first half of the month", new test case added which resolves as expected "私は月の前半は北京にいません"
- "二分間前の価格はこの三十分間のピックになった。" updated resolution because it translates to "The price two minutes ago was a pick for the last thirty minutes." instead of "The price hit a 30-minute high 2 minutes ago" (it is not possible to have a more faithful translation)
- "１２日" returns an extraction because "日" unambiguously indicates a day
- "１０月から来年の５月までの間のデータをいただけますか？" updated resolution because it translates to "Can you give me the data from October to May next year?" instead of "Can you give me the data between October and May?". Added new test case with the expected resolution "１０月から５月までの間のデータをいただけますか？"
- Other small changes like:
     - Adding/removing prepositions from the extraction (e.g. "に", "で", "の間"...)
     - Adding/modifying modifiers when translations do not match exactly the original meaning (e.g. "around 3pm" instead of "3pm", "after monday" instead of "on or after monday"...)


