### PR TITLE
[DE DateTimeV2] Fixed German date recognition inconsistent if containing ordinal numbers as words (#2985)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -35,8 +35,11 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string ThisPrefixRegex = @"\b(diese[rnms]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?)\b";
       public const string RangePrefixRegex = @"(vo[nm]|zwischen)";
       public const string PenultimatePrefixRegex = @"\b(vorletzte[snm]?)\b";
+      public const string WrittenOneToNineRegex = @"(eins?|zw(een|ei|o)|drei|vier|fünf|fuenf|sechs|sieben|acht|neun)";
       public const string DayRegex = @"(de[rmsn]\s*)?(?<day>(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(\.|\b))";
-      public const string MonthNumRegex = @"(?<month>(01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\.?)";
+      public static readonly string WrittenDayNumRegex = $@"\b(?<day>(?<ordinal>((erst|zweit|dritt|viert|fünft|fuenft|sechst|siebt|acht|neunt|zehnt|elft|zwölft|zwoelft|dreizehnt|vierzehnt|fünfzehnt|fuenfzehnt|sechzehnt|siebzehnt|achtzehnt|neunzehnt)er|({WrittenOneToNineRegex}und)?zwanzigster|(einund)?dreißigster)))\b";
+      public const string MonthNumRegex = @"(?<month>(01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)(\.|\b))";
+      public const string WrittenMonthNumRegex = @"\b(?<month>(?<ordinal>((erst|zweit|dritt|viert|fünft|fuenft|sechst|siebt|acht|neunt|zehnt|elft|zw(ö|oe)lft)er)))\b";
       public static readonly string AmDescRegex = $@"({BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
       public static readonly string AmPmDescRegex = $@"({BaseDateTime.BaseAmPmDescRegex})";
@@ -44,7 +47,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string DescRegex = $@"({OclockRegex})";
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public const string CenturyRegex = @"\b(?<century>((ein|zwei)?tausend(und)?)?((ein|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn|elf|zwölf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn)hundert))\b";
-      public const string WrittenNumRegex = @"(zw(ö|oe)lf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn|zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig|eins?|zw(een|ei|o)|drei|vier|fünf|fuenf|sechs|sieben|acht|neun|zehn|elf)";
+      public static readonly string WrittenNumRegex = $@"(zw(ö|oe)lf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn|zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig|elf|zehn|{WrittenOneToNineRegex})";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>((zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig)\s+{WrittenNumRegex})|{WrittenNumRegex}))\b|\b(?<firsttwoyearnum>{CenturyRegex})\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
       public const string WeekDayRegex = @"(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|sonnabend|(mo|di|mi|do|fr|sa|so)(\.|\b))";
@@ -105,6 +108,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string DateExtractor8 = $@"(?<=\b(am)\s+){DayRegex}[/\\\.]{MonthNumRegex}([/\\\.]{DateYearRegex})?{BaseDateTime.CheckDecimalRegex}\b";
       public static readonly string DateExtractor9 = $@"\b({DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*){DateYearRegex})?){BaseDateTime.CheckDecimalRegex}\b";
       public static readonly string DateExtractor10 = $@"^[.]";
+      public static readonly string DateExtractor11 = $@"\b(({WeekDayRegex})(\s+|\s*,\s*)|(?<=\bam\s+))({DayRegex}\.|{WrittenDayNumRegex})\s*[/\\.\- ]\s*({MonthNumRegex}\.|{WrittenMonthNumRegex})(\s*[/\\.\- ]\s*{DateYearRegex})?";
       public static readonly string DateExtractorA = $@"({DateYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{DayRegex}|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})(?!\s*[/\\\-\.:]\s*\d+)";
       public static readonly string OfMonth = $@"^(\s*des\s*|\s*)?{MonthRegex}";
       public static readonly string MonthEnd = $@"{MonthRegex}\s*(de[rmn])?\s*$";
@@ -452,7 +456,21 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"06", 6 },
             { @"07", 7 },
             { @"08", 8 },
-            { @"09", 9 }
+            { @"09", 9 },
+            { @"erster", 1 },
+            { @"zweiter", 2 },
+            { @"dritter", 3 },
+            { @"vierter", 4 },
+            { @"fünfter", 5 },
+            { @"fuenfter", 5 },
+            { @"sechster", 6 },
+            { @"siebter", 7 },
+            { @"achter", 8 },
+            { @"neunter", 9 },
+            { @"zehnter", 10 },
+            { @"elfter", 11 },
+            { @"zwölfter", 12 },
+            { @"zwoelfter", 12 }
         };
       public static readonly Dictionary<string, int> Numbers = new Dictionary<string, int>
         {
@@ -626,7 +644,42 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"28", 28 },
             { @"29", 29 },
             { @"30", 30 },
-            { @"31", 31 }
+            { @"31", 31 },
+            { @"erster", 1 },
+            { @"zweiter", 2 },
+            { @"dritter", 3 },
+            { @"vierter", 4 },
+            { @"fünfter", 5 },
+            { @"fuenfter", 5 },
+            { @"sechster", 6 },
+            { @"siebter", 7 },
+            { @"achter", 8 },
+            { @"neunter", 9 },
+            { @"zehnter", 10 },
+            { @"elfter", 11 },
+            { @"zwölfter", 12 },
+            { @"zwoelfter", 12 },
+            { @"dreizehnter", 13 },
+            { @"vierzehnter", 14 },
+            { @"fünfzehnter", 15 },
+            { @"fuenfzehnter", 15 },
+            { @"sechzehnter", 16 },
+            { @"siebzehnter", 17 },
+            { @"achtzehnter", 18 },
+            { @"neunzehnter", 19 },
+            { @"zwanzigster", 20 },
+            { @"einundzwanzigster", 21 },
+            { @"zweiundzwanzigster", 22 },
+            { @"dreiundzwanzigster", 23 },
+            { @"vierundzwanzigster", 24 },
+            { @"fünfundzwanzigster", 25 },
+            { @"fuenfundzwanzigster", 25 },
+            { @"sechsundzwanzigster", 26 },
+            { @"siebenundzwanzigster", 27 },
+            { @"achtundzwanzigster", 28 },
+            { @"neunundzwanzigster", 29 },
+            { @"dreißigster", 30 },
+            { @"einunddreißigster", 31 }
         };
       public static readonly Dictionary<string, double> DoubleNumbers = new Dictionary<string, double>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -175,6 +175,9 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             // Nächstes Jahr (im Sommer)?
             var dateRegex10 = new Regex(DateTimeDefinitions.DateExtractor10, RegexFlags);
 
+            // (Sonntag,)? 23. siebter (2016)?
+            var dateRegex11 = new Regex(DateTimeDefinitions.DateExtractor11, RegexFlags);
+
             // 2015-12-23
             var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
@@ -194,8 +197,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY;
 
             DateRegexList = DateRegexList.Concat(enableDmy ?
-                new[] { dateRegex5, dateRegex8, dateRegex9, dateRegex4, dateRegex6, dateRegex7, dateRegex10, dateRegexA } :
-                new[] { dateRegex4, dateRegex6, dateRegex7, dateRegex5, dateRegex8, dateRegex9, dateRegex10, dateRegexA });
+                new[] { dateRegex5, dateRegex8, dateRegex9, dateRegex4, dateRegex6, dateRegex7, dateRegex10, dateRegex11, dateRegexA } :
+                new[] { dateRegex4, dateRegex6, dateRegex7, dateRegex5, dateRegex8, dateRegex9, dateRegex10, dateRegex11, dateRegexA });
         }
 
         public IEnumerable<Regex> DateRegexList { get; }

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -30,10 +30,17 @@ RangePrefixRegex: !simpleRegex
   def: (vo[nm]|zwischen)
 PenultimatePrefixRegex: !simpleRegex
   def: \b(vorletzte[snm]?)\b
+WrittenOneToNineRegex: !simpleRegex
+  def: (eins?|zw(een|ei|o)|drei|vier|fünf|fuenf|sechs|sieben|acht|neun)
 DayRegex: !simpleRegex
   def: (de[rmsn]\s*)?(?<day>(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(\.|\b))
+WrittenDayNumRegex: !nestedRegex
+  def: \b(?<day>(?<ordinal>((erst|zweit|dritt|viert|fünft|fuenft|sechst|siebt|acht|neunt|zehnt|elft|zwölft|zwoelft|dreizehnt|vierzehnt|fünfzehnt|fuenfzehnt|sechzehnt|siebzehnt|achtzehnt|neunzehnt)er|({WrittenOneToNineRegex}und)?zwanzigster|(einund)?dreißigster)))\b
+  references: [ WrittenOneToNineRegex ]
 MonthNumRegex: !simpleRegex
-  def: (?<month>(01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\.?)
+  def: (?<month>(01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)(\.|\b))
+WrittenMonthNumRegex: !simpleRegex
+  def: \b(?<month>(?<ordinal>((erst|zweit|dritt|viert|fünft|fuenft|sechst|siebt|acht|neunt|zehnt|elft|zw(ö|oe)lft)er)))\b
 AmDescRegex: !nestedRegex
   def: ({BaseDateTime.BaseAmDescRegex})
   references: [BaseDateTime.BaseAmDescRegex]
@@ -53,8 +60,9 @@ TwoDigitYearRegex: !nestedRegex
   references: [ AmDescRegex, PmDescRegex]
 CenturyRegex: !simpleRegex
   def: \b(?<century>((ein|zwei)?tausend(und)?)?((ein|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn|elf|zwölf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn)hundert))\b
-WrittenNumRegex: !simpleRegex
-  def: (zw(ö|oe)lf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn|zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig|eins?|zw(een|ei|o)|drei|vier|fünf|fuenf|sechs|sieben|acht|neun|zehn|elf)
+WrittenNumRegex: !nestedRegex
+  def: (zw(ö|oe)lf|dreizehn|vierzehn|fünfzehn|sechzehn|siebzehn|achtzehn|neunzehn|zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig|elf|zehn|{WrittenOneToNineRegex})
+  references: [ WrittenOneToNineRegex ]
 FullTextYearRegex: !nestedRegex
   def: \b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>((zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig)\s+{WrittenNumRegex})|{WrittenNumRegex}))\b|\b(?<firsttwoyearnum>{CenturyRegex})\b
   references: [ CenturyRegex, WrittenNumRegex ]
@@ -222,6 +230,9 @@ DateExtractor10: !nestedRegex
   def: ^[.]
   #def: \b({RelativeRegex}\s*jahr(\s*im)?({MonthNumRegex}|sommer|winter|frühling|herbst)?)\b
   references: [ DayRegex, MonthNumRegex, DateYearRegex, RelativeRegex ]
+DateExtractor11: !nestedRegex
+  def: \b(({WeekDayRegex})(\s+|\s*,\s*)|(?<=\bam\s+))({DayRegex}\.|{WrittenDayNumRegex})\s*[/\\.\- ]\s*({MonthNumRegex}\.|{WrittenMonthNumRegex})(\s*[/\\.\- ]\s*{DateYearRegex})?
+  references: [ WeekDayRegex, MonthNumRegex, DayRegex, DateYearRegex, WrittenMonthNumRegex, WrittenDayNumRegex ]
 DateExtractorA: !nestedRegex
   def: ({DateYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{DayRegex}|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})(?!\s*[/\\\-\.:]\s*\d+)
   references: [ DateYearRegex, MonthNumRegex, MonthRegex, DayRegex, BaseDateTime.FourDigitYearRegex ]
@@ -799,6 +810,20 @@ MonthOfYear: !dictionary
     '07': 7
     '08': 8
     '09': 9
+    'erster': 1
+    'zweiter': 2
+    'dritter': 3
+    'vierter': 4
+    'fünfter': 5
+    'fuenfter': 5
+    'sechster': 6
+    'siebter': 7
+    'achter': 8
+    'neunter': 9
+    'zehnter': 10
+    'elfter': 11
+    'zwölfter': 12
+    'zwoelfter': 12
 Numbers: !dictionary
   types: [ string, int ]
   entries:
@@ -973,6 +998,41 @@ DayOfMonth: !dictionary
     '29': 29
     '30': 30
     '31': 31
+    'erster': 1
+    'zweiter': 2
+    'dritter': 3
+    'vierter': 4
+    'fünfter': 5
+    'fuenfter': 5
+    'sechster': 6
+    'siebter': 7
+    'achter': 8
+    'neunter': 9
+    'zehnter': 10
+    'elfter': 11
+    'zwölfter': 12
+    'zwoelfter': 12
+    'dreizehnter': 13
+    'vierzehnter': 14
+    'fünfzehnter': 15
+    'fuenfzehnter': 15
+    'sechzehnter': 16
+    'siebzehnter': 17
+    'achtzehnter': 18
+    'neunzehnter': 19
+    'zwanzigster': 20
+    'einundzwanzigster': 21
+    'zweiundzwanzigster': 22
+    'dreiundzwanzigster': 23
+    'vierundzwanzigster': 24
+    'fünfundzwanzigster': 25
+    'fuenfundzwanzigster': 25
+    'sechsundzwanzigster': 26
+    'siebenundzwanzigster': 27
+    'achtundzwanzigster': 28
+    'neunundzwanzigster': 29
+    'dreißigster': 30
+    'einunddreißigster': 31
 DoubleNumbers: !dictionary
   types: [ string, double ]
   entries: 

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -5325,5 +5325,240 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Ich komme am siebter 4. zurück.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "siebter 4.",
+        "Start": 13,
+        "End": 22,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2016-04-07"
+            },
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2017-04-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich komme am 7. vierter zurück.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "7. vierter",
+        "Start": 13,
+        "End": 22,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2016-04-07"
+            },
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2017-04-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich komme 7. vierter zurück.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": []
+  },
+  {
+    "Input": "Ich komme am Donnerstag siebter 4. zurück.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "donnerstag siebter 4.",
+        "Start": 13,
+        "End": 33,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2016-04-07"
+            },
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2017-04-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich komme am Donnerstag 7. vierter zurück.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "donnerstag 7. vierter",
+        "Start": 13,
+        "End": 33,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2016-04-07"
+            },
+            {
+              "timex": "XXXX-04-07",
+              "type": "date",
+              "value": "2017-04-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Das treffen ist Donnerstag 7. vierter 2016.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "donnerstag 7. vierter 2016",
+        "Start": 16,
+        "End": 41,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-04-07",
+              "type": "date",
+              "value": "2016-04-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Das treffen ist am 27. 11.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "27. 11.",
+        "Start": 19,
+        "End": 25,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-11-27",
+              "type": "date",
+              "value": "2015-11-27"
+            },
+            {
+              "timex": "XXXX-11-27",
+              "type": "date",
+              "value": "2016-11-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Das treffen ist am dritter/11.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "dritter/11.",
+        "Start": 19,
+        "End": 29,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-11-03",
+              "type": "date",
+              "value": "2016-11-03"
+            },
+            {
+              "timex": "XXXX-11-03",
+              "type": "date",
+              "value": "2017-11-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Das treffen ist Montag zwölfter fünfter.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "montag zwölfter fünfter",
+        "Start": 16,
+        "End": 38,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-05-12",
+              "type": "date",
+              "value": "2016-05-12"
+            },
+            {
+              "timex": "XXXX-05-12",
+              "type": "date",
+              "value": "2017-05-12"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2985.

Test cases added to DateTimeModel.