### PR TITLE
[EN DateTimeV2] Fixed incorrect parsing of period mentions like 'last two quarters' (#2656)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
       public const string QuarterTermRegex = @"\b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(q(?<number>[1-4])))\b";
-      public static readonly string RelativeQuarterTermRegex = $@"\b(?<orderQuarter>{StrictRelativeRegex})\s+quarter\b";
+      public static readonly string RelativeQuarterTermRegex = $@"\b(?<orderQuarter>{StrictRelativeRegex})\s+((?<num>[\w,]+)\s+)?quarters?\b";
       public static readonly string QuarterRegex = $@"((the\s+)?{QuarterTermRegex}(?:((\s+of)?\s+|\s*[,-]\s*)({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}";
       public static readonly string QuarterRegexYearFront = $@"(?:{YearRegex}|{RelativeRegex}\s+year)('s)?(?:\s*-\s*|\s+(the\s+)?)?{QuarterTermRegex}";
       public const string HalfYearTermRegex = @"(?<cardinal>first|1st|second|2nd)\s+half";

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
@@ -143,6 +143,7 @@ class ChineseDatePeriodParserConfiguration implements IDatePeriodParserConfigura
     readonly dateParser: BaseDateParser
     readonly durationExtractor: ChineseDurationExtractor
     readonly durationParser: BaseDurationParser
+    readonly integerExtractor: BaseNumberExtractor
     readonly numberParser: BaseNumberParser
     readonly monthFrontBetweenRegex: RegExp
     readonly betweenRegex: RegExp

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/english/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/english/datePeriodConfiguration.ts
@@ -104,6 +104,7 @@ export class EnglishDatePeriodParserConfiguration implements IDatePeriodParserCo
     readonly dateParser: BaseDateParser
     readonly durationExtractor: IDateTimeExtractor
     readonly durationParser: BaseDurationParser
+    readonly integerExtractor: BaseNumberExtractor
     readonly numberParser: BaseNumberParser
     readonly monthFrontBetweenRegex: RegExp
     readonly betweenRegex: RegExp
@@ -147,6 +148,7 @@ export class EnglishDatePeriodParserConfiguration implements IDatePeriodParserCo
         this.durationExtractor = config.durationExtractor;
         this.durationParser = config.durationParser;
         this.numberParser = config.numberParser;
+        this.integerExtractor = config.integerExtractor;
         this.monthFrontBetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontBetweenRegex);
         this.betweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BetweenRegex);
         this.monthFrontSimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontSimpleCasesRegex);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
@@ -141,12 +141,14 @@ export class FrenchDatePeriodParserConfiguration implements IDatePeriodParserCon
     readonly weekWithWeekDayRangeRegex: RegExp;
 
     readonly cardinalExtractor: IExtractor;
+    readonly integerExtractor: BaseNumberExtractor;
     readonly numberParser: BaseNumberParser;
     readonly nowRegex: RegExp
 
     constructor(config: ICommonDateTimeParserConfiguration) {
         this.tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
         this.cardinalExtractor = config.cardinalExtractor;
+        this.integerExtractor = config.integerExtractor;
         this.numberParser = config.numberParser;
         this.durationExtractor = config.durationExtractor;
         this.dateExtractor = config.dateExtractor;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
@@ -139,12 +139,14 @@ export class SpanishDatePeriodParserConfiguration implements IDatePeriodParserCo
     readonly numberCombinedWithUnit: RegExp;
 
     readonly cardinalExtractor: IExtractor;
+    readonly integerExtractor: BaseNumberExtractor;
     readonly numberParser: BaseNumberParser;
     readonly nowRegex: RegExp
 
     constructor(config: ICommonDateTimeParserConfiguration) {
         this.tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
         this.cardinalExtractor = config.cardinalExtractor;
+        this.integerExtractor = config.integerExtractor;
         this.numberParser = config.numberParser;
         this.durationExtractor = config.durationExtractor;
         this.dateExtractor = config.dateExtractor;

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -189,7 +189,7 @@ NumberCombinedWithDateUnit: !nestedRegex
 QuarterTermRegex: !simpleRegex
   def: \b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(q(?<number>[1-4])))\b
 RelativeQuarterTermRegex: !nestedRegex
-  def: \b(?<orderQuarter>{StrictRelativeRegex})\s+quarter\b
+  def: \b(?<orderQuarter>{StrictRelativeRegex})\s+((?<num>[\w,]+)\s+)?quarters?\b
   references: [ StrictRelativeRegex ]
 QuarterRegex: !nestedRegex
   def: ((the\s+)?{QuarterTermRegex}(?:((\s+of)?\s+|\s*[,-]\s*)({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -24507,5 +24507,230 @@
         }
       }
     ]
+  },
+  {
+    "Input": "What are the sales for the last quarter",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "last quarter",
+        "Start": 27,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-04-01,2019-07-01,P3M)",
+              "type": "daterange",
+              "start": "2019-04-01",
+              "end": "2019-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the last 2 quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "last 2 quarters",
+        "Start": 27,
+        "End": 41,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2019-07-01,P6M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the past two quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "past two quarters",
+        "Start": 27,
+        "End": 43,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2019-07-01,P6M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the previous three quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "previous three quarters",
+        "Start": 27,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2019-07-01,P9M)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2019-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the previous eleven quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "previous eleven quarters",
+        "Start": 27,
+        "End": 50,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-10-01,2019-07-01,P33M)",
+              "type": "daterange",
+              "start": "2016-10-01",
+              "end": "2019-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the next quarter",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "next quarter",
+        "Start": 27,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-10-01,2020-01-01,P3M)",
+              "type": "daterange",
+              "start": "2019-10-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the following 2 quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "following 2 quarters",
+        "Start": 27,
+        "End": 46,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-10-01,2020-04-01,P6M)",
+              "type": "daterange",
+              "start": "2019-10-01",
+              "end": "2020-04-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the coming three quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "coming three quarters",
+        "Start": 27,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-10-01,2020-07-01,P9M)",
+              "type": "daterange",
+              "start": "2019-10-01",
+              "end": "2020-07-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "What are the sales for the next 7 quarters",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "next 7 quarters",
+        "Start": 27,
+        "End": 41,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-10-01,2021-07-01,P21M)",
+              "type": "daterange",
+              "start": "2019-10-01",
+              "end": "2021-07-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2656 in .NET and JavaScript.

Did not tackle the pattern in Number because it does not seem wrong to extract "two quarters" as fraction. 
I can find expressions that use it, e.g. "the last two quarters of the book are dedicated to it".

Test cases added to DateTimeModel.