### PR TITLE
[* DateTimeV2] Removed extraction of expressions like '1:1' as time

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/BaseDateTime.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/BaseDateTime.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Recognizers.Definitions
     {
       public const string HourRegex = @"(?<!\d[,.])(?<hour>2[0-4]|[0-1]?\d)(h)?";
       public const string TwoDigitHourRegex = @"(?<hour>[0-1]\d|2[0-4])(h)?";
-      public const string MinuteRegex = @"(?<min>[0-5]?\d)(?!\d)";
+      public const string MinuteRegex = @"(?<min>[0-5]\d)(?!\d)";
       public const string TwoDigitMinuteRegex = @"(?<min>[0-5]\d)(?!\d)";
       public const string DeltaMinuteRegex = @"(?<deltamin>[0-5]?\d)";
       public const string SecondRegex = @"(?<sec>[0-5]?\d)";

--- a/Patterns/Base-DateTime.yaml
+++ b/Patterns/Base-DateTime.yaml
@@ -3,7 +3,7 @@ HourRegex: !simpleRegex
 TwoDigitHourRegex: !simpleRegex
   def: (?<hour>[0-1]\d|2[0-4])(h)?
 MinuteRegex: !simpleRegex
-  def: (?<min>[0-5]?\d)(?!\d)
+  def: (?<min>[0-5]\d)(?!\d)
 TwoDigitMinuteRegex: !simpleRegex
   def: (?<min>[0-5]\d)(?!\d)
 DeltaMinuteRegex: !simpleRegex

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -24272,5 +24272,40 @@
         }
       }
     ]
+  },
+  {
+    "Input": "schedule me a 1:1 on monday",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "monday",
+        "Start": 21,
+        "End": 26,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "date",
+              "value": "2016-10-31"
+            },
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "date",
+              "value": "2016-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This screen has a 4:3 aspect ratio.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": []
   }
 ]


### PR DESCRIPTION
Fix as for [comment](https://github.com/microsoft/Recognizers-Text/pull/2992#discussion_r919874202) in PR #2992.

Test cases added to EN DateTimeModel.