### PR TITLE
[Python] Update dependency to latest emoji pkg

### DIFF
--- a/Python/libraries/recognizers-text/recognizers_text/utilities.py
+++ b/Python/libraries/recognizers-text/recognizers_text/utilities.py
@@ -5,15 +5,18 @@ import re
 import unicodedata
 from typing import Pattern, Union, List, Match, Dict
 import regex
-from emoji import UNICODE_EMOJI
+from emoji import demojize
 from multipledispatch import dispatch
 
 
 class StringUtility:
     @staticmethod
     def is_emoji(letter):
-        return letter in UNICODE_EMOJI["en"]
-
+        val = demojize(letter)
+        if letter in val:
+            return False
+        else:
+            return True
     @staticmethod
     def remove_unicode_matches(string: Pattern):
         py_regex = re.sub('\\\\u.{4}[\\|\\\\]', '', string.pattern)

--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text"
 VERSION = "1.0.0.a0"
-REQUIRES = ['emoji==1.1.0', 'multipledispatch']
+REQUIRES = ['emoji==2.0.0', 'multipledispatch']
 
 setup(
     name=NAME,


### PR DESCRIPTION
Modified  Python\libraries\recognizers-text\recognizers_text\utilities.py in accordance with the changes in the latest emoji package (version 2.0.0).

Changed the **UNICODE** import to **demojize** as UNICODE was deprecated in **emoji==2.0.0**. Made changes to the is_emoji function in  Python\libraries\recognizers-text\recognizers_text\utilities.py in accordance with the demojize import.

Updated the requirements in setup to emoji==2.0.0