### PR TITLE
Fshakerin/ja

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
@@ -82,5 +82,8 @@ namespace Microsoft.Recognizers.Text.Number
             FRACTION,
             POWER,
         };
+
+        public static readonly int DEFAULT_MATCH_TIMEOUT_IN_SECONDS = 5;
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                 },
                 {
                     // 五分の二   七分の三
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags, TimeSpan.FromSeconds(5)),
+                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags, TimeSpan.FromSeconds(Constants.DEFAULT_MATCH_TIMEOUT_IN_SECONDS)),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
@@ -30,7 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                 },
                 {
                     // 五分の二   七分の三
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags),
+                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags, TimeSpan.FromSeconds(5)),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
                 },
             };


### PR DESCRIPTION
Adding a timeout to Japanese Fraction extractor RegEx.
The extractor would run for a long time (couple of minutes) on the following input:
"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
