### PR TITLE
- adding a timeout to japanese fraction extraction

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
@@ -82,5 +82,7 @@ namespace Microsoft.Recognizers.Text.Number
             FRACTION,
             POWER,
         };
+
+        public static readonly int DEFAULT_TIMEOUT_IN_SECONDS = 5;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
@@ -30,7 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                 },
                 {
                     // 五分の二   七分の三
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags),
+                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags, TimeSpan.FromSeconds(Constants.DEFAULT_TIMEOUT_IN_SECONDS)),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
                 },
             };


### PR DESCRIPTION
Adding a timeout to Japanese Fraction extractor RegEx.
The extractor would run for a long time (couple of minutes) on the following input:
"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"