### PR TITLE
[EN DateTimeV2] Fixing failing timexlib unit test

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexParsing.cs
@@ -51,10 +51,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var indexOfT = s.IndexOf('T');
             var indexOfP = s.IndexOf('P');
 
+            // Spring timex value has a P in it, but should not be mixed up with
+            // the "period" types that have P in them
+            var indexOfSP = s.IndexOf("SP");
+
             if (indexOfT == -1)
             {
                 var extracted = new Dictionary<string, string>();
-                if (indexOfP == -1)
+                if (indexOfSP > -1 || indexOfP == -1)
                 {
                     TimexRegex.Extract("date", s, extracted);
                 }


### PR DESCRIPTION
Converting sets to string has a failing unit test on "SP" or "every spring". Parsing DateTime expressions relies on the fact that presence of "T" and "P" always indicates time and period respectively. There is an exception and that is the string "SP" that indicates "spring" and not the reserved character "P" in the iso8601 standard.