### PR TITLE
[Infra] Fixing component governmence vulnarabilities and OneBranch changes

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
@@ -19,6 +19,14 @@
       -->
       <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
       <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, boolean, alternatives, choices, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.Choice provides recognition of Boolean (yes/no) answers expressed in English, Portuguese, Spanish, Japanese, Chinese,
+       Dutch, French, German, Italian, Swedish, Bulgarian, Turkish, Hindi, and Arabic. As well as base classes to support lists of alternative choices.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.csproj
@@ -19,6 +19,13 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, timex, datatime, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.DataTypes.TimexExpression provides parsing and evaluation of TIMEX expressions.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>  
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' ">

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
@@ -19,6 +19,14 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, date, time, datetime, numex, timex, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.DateTime provides robust recognition and resolution of Date and Time expressed in English, Spanish, French, Portuguese, Chinese,
+     German, Italian, and Turkish.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
@@ -19,6 +19,14 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, numex, numbers, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.Number provides robust recognition and resolution of numbers expressed in English, Spanish, French, Portuguese, Chinese,
+    German, Dutch, Japanese, Italian, Turkish, Swedish, and Hindi.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
@@ -19,6 +19,14 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, numex, units, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.NumberWithUnit provides robust recognition and resolution of numbers with units expressed in English, Spanish, French, Portuguese, Chinese,
+    German, Dutch, Italian, Turkish, and Hindi.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
@@ -19,6 +19,13 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, phonenumber, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text.Sequence provides robust recognition and resolution of series entities like phone numbers, URLs, and e-mail and IP addresses.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
@@ -19,6 +19,13 @@
 	  -->
 	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
 	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+      <Authors>Microsoft</Authors>
+      <PackageTags>nlp, entity-extraction, parser-library, recognizer, text, netstandard2.0</PackageTags>
+      <Description>Microsoft.Recognizers.Text provides base classes for robust recognition and resolution of text entities.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageProjectUrl>https://github.com/Microsoft/Recognizers-Text</PackageProjectUrl>
+      <icon>images\icon.png</icon>
+      <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Samples/BotBuilder/BotBuilderRecognizerBot.csproj
+++ b/.NET/Samples/BotBuilder/BotBuilderRecognizerBot.csproj
@@ -18,8 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>    
-    <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.22" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.22" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.2" />

--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -11,8 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <ProjectReference Include="..\..\Microsoft.Recognizers.Text.DateTime\Microsoft.Recognizers.Text.DateTime.csproj" />

--- a/JavaScript/packages/datatypes-date-time/package-lock.json
+++ b/JavaScript/packages/datatypes-date-time/package-lock.json
@@ -16,7 +16,7 @@
 				"check-error": "^1.0.1",
 				"deep-eql": "^3.0.0",
 				"get-func-name": "^2.0.0",
-				"pathval": "^1.0.0",
+				"pathval": "^1.1.1",
 				"type-detect": "^4.0.0"
 			}
 		},
@@ -47,9 +47,9 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
 		},
 		"type-detect": {
 			"version": "4.0.8",


### PR DESCRIPTION
- Updating some packages to address the Azure OneBranch component governance errors.
- Adding the packages metadata to the .csproj files. This was needed so that the dotnet pack command that will be used in the new onebranch pipeline adds the same metadata that the packages contain today. 