### PR TITLE
Bump up npm package versions to 1.3.1

### DIFF
--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recognizers",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/JavaScript/packages/datatypes-date-time/package.json
+++ b/JavaScript/packages/datatypes-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-data-types-timex-expression",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Support for TIMEX-based representation of datetime entities",
   "author": "Microsoft",
   "license": "MIT",

--- a/JavaScript/packages/recognizers-choice/package.json
+++ b/JavaScript/packages/recognizers-choice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-choice",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-choice provides recognition of Boolean (yes/no) answers expressed in multiple languages, as well as base classes to support lists of alternative choices.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "grapheme-splitter": "^1.0.2"
   }
 }

--- a/JavaScript/packages/recognizers-date-time/package.json
+++ b/JavaScript/packages/recognizers-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-date-time",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text provides robust recognition and resolution of date/time expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "@microsoft/recognizers-text": "~1.3.0",
-    "@microsoft/recognizers-text-number": "~1.3.0",
-    "@microsoft/recognizers-text-number-with-unit": "~1.3.0"
+    "@microsoft/recognizers-text": "~1.3.1",
+    "@microsoft/recognizers-text-number": "~1.3.1",
+    "@microsoft/recognizers-text-number-with-unit": "~1.3.1"
   }
 }

--- a/JavaScript/packages/recognizers-number-with-unit/package.json
+++ b/JavaScript/packages/recognizers-number-with-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-number-with-unit",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-number-with-unit provides robust recognition and resolution of numbers with units expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "@microsoft/recognizers-text": "~1.3.0",
-    "@microsoft/recognizers-text-number": "~1.3.0"
+    "@microsoft/recognizers-text": "~1.3.1",
+    "@microsoft/recognizers-text-number": "~1.3.1"
   }
 }

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-number",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-number provides robust recognition and resolution of numbers expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "bignumber.js": "^7.2.1",
     "lodash": "^4.17.21"
   }

--- a/JavaScript/packages/recognizers-sequence/package.json
+++ b/JavaScript/packages/recognizers-sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-sequence",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-sequence provides robust recognition and resolution of series entities like phone numbers, URLs, and e-mail and IP addresses.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "grapheme-splitter": "^1.0.2"
   }
 }

--- a/JavaScript/packages/recognizers-text-suite/package.json
+++ b/JavaScript/packages/recognizers-text-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-suite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-suite provides robust recognition and resolution of numbers, units, date/time, and more; expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,12 +32,12 @@
     "prepare": "npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
-    "@microsoft/recognizers-text": "~1.3.0",
-    "@microsoft/recognizers-text-number": "~1.3.0",
-    "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-    "@microsoft/recognizers-text-date-time": "~1.3.0",
-    "@microsoft/recognizers-text-sequence": "~1.3.0",
-    "@microsoft/recognizers-text-choice": "~1.3.0"
+    "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.1",
+    "@microsoft/recognizers-text": "~1.3.1",
+    "@microsoft/recognizers-text-number": "~1.3.1",
+    "@microsoft/recognizers-text-number-with-unit": "~1.3.1",
+    "@microsoft/recognizers-text-date-time": "~1.3.1",
+    "@microsoft/recognizers-text-sequence": "~1.3.1",
+    "@microsoft/recognizers-text-choice": "~1.3.1"
   }
 }

--- a/JavaScript/packages/recognizers-text/package.json
+++ b/JavaScript/packages/recognizers-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text provides base classes for robust recognition and resolution of text entities.",
   "author": "Microsoft Corp.",
   "license": "MIT",


### PR DESCRIPTION
### Description
Bumping up npm packages version to 1.3.1

### Testing
Changes were tested by building and running them via instructions on https://github.com/Microsoft/Recognizers-Text/tree/master/JavaScript/packages/recognizers-text-suite.

build successful before updating package versions :
<img width="856" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/4d50ed33-8755-4abf-a263-709f4631a3b8">


Tests successful before updating package versions :
<img width="670" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/016bc457-efdf-4ab4-89ed-18481997c379">

