### PR TITLE
Bump choice sequence and number package versions

### DIFF
--- a/JavaScript/packages/recognizers-choice/package.json
+++ b/JavaScript/packages/recognizers-choice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-choice",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-choice provides recognition of Boolean (yes/no) answers expressed in multiple languages, as well as base classes to support lists of alternative choices.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "grapheme-splitter": "^1.0.2"
   }
 }

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-number",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-number provides robust recognition and resolution of numbers expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "bignumber.js": "^7.2.1",
     "lodash": "^4.17.21"
   }

--- a/JavaScript/packages/recognizers-sequence/package.json
+++ b/JavaScript/packages/recognizers-sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-sequence",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text-sequence provides robust recognition and resolution of series entities like phone numbers, URLs, and e-mail and IP addresses.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.1",
     "grapheme-splitter": "^1.0.2"
   }
 }


### PR DESCRIPTION
### Description
Bumps packages which only depend on recognizers text and updates the version of the dependency used to 1.3.1

### Testing
Ran build and test successfully in parent Javascript directory:

Successful Build
<img width="356" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/4ac4b53b-44cf-4e4c-a0b8-eb04ebb22197">

Successful Test
<img width="486" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/c8093917-4ad9-4b8d-9306-0e27826b6017">

