### PR TITLE
Bump npm version for recognizers date time

### DIFF
--- a/JavaScript/packages/recognizers-date-time/package.json
+++ b/JavaScript/packages/recognizers-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-date-time",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "recognizers-text provides robust recognition and resolution of date/time expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "@microsoft/recognizers-text": "~1.3.0",
-    "@microsoft/recognizers-text-number": "~1.3.0",
-    "@microsoft/recognizers-text-number-with-unit": "~1.3.0"
+    "@microsoft/recognizers-text": "~1.3.1",
+    "@microsoft/recognizers-text-number": "~1.3.1",
+    "@microsoft/recognizers-text-number-with-unit": "~1.3.1"
   }
 }


### PR DESCRIPTION
### Description
Bump the npm version for recognizers date time.
Also bump the dependencies version accordingly.

### Testing
Ran npm install, npm run build and npm run test locally

successful build
<img width="336" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/5d129c09-e220-441b-8333-8bd2e5956602">


successful test
<img width="403" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/881a8010-c554-421e-a192-629395c5b5ca">
