### PR TITLE
Fix build failure for recognizers date time

### DIFF
--- a/JavaScript/packages/recognizers-date-time/package.json
+++ b/JavaScript/packages/recognizers-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-date-time",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "recognizers-text provides robust recognition and resolution of date/time expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+declare var require: any
 
 import { IMergedExtractorConfiguration, BaseMergedExtractor, IMergedParserConfiguration, BaseMergedParser } from "../baseMerged";
 import { BaseDateExtractor, BaseDateParser } from "../baseDate";
@@ -27,7 +28,7 @@ import { DateTimeOptions } from "../dateTimeRecognizer";
 import { IDateTimeParser, DateTimeParseResult } from "../parsers";
 import { Constants, TimeTypeConstants } from "../constants";
 import { DateTimeFormatUtil, DateUtils, DateTimeResolutionResult, StringMap } from "../utilities";
-import isEqual = require('lodash.isequal');
+const lodash = require('lodash');
 
 class ChineseMergedExtractorConfiguration implements IMergedExtractorConfiguration {
     readonly dateExtractor: BaseDateExtractor
@@ -499,7 +500,7 @@ export class ChineseFullMergedParser extends BaseMergedParser {
 
         let futureValues = Array.from(this.getValues(future)).sort();
         let pastValues = Array.from(this.getValues(past)).sort();
-        if (isEqual(futureValues, pastValues)) {
+        if (lodash.isEqual(futureValues, pastValues)) {
             if (pastValues.length > 0) {
                 this.addResolutionFieldsAny(result, Constants.ResolveKey, past);
             }


### PR DESCRIPTION
### Description
Fix npm build for recognizers datetime and bump the npm version for recognizers date time.

Testing
Ran npm install, npm run build and npm run test locally

successful build
<img width="268" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/e6347d54-9a37-4b5f-b2d1-11644537d58d">

successful test
<img width="310" alt="image" src="https://github.com/microsoft/Recognizers-Text/assets/4621120/b3bfd568-1df5-4ce1-a57a-edba4984ce1f">

