### PR TITLE
Fix wrong resolution for some fractions

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.xml
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.xml
@@ -167,6 +167,15 @@
             <param name="extResult">input arabic number.</param>
             <returns>parsed result.</returns>
         </member>
+        <member name="M:Microsoft.Recognizers.Text.Number.BaseNumberParser.GetSplitIndex(System.Collections.Generic.List{System.String})">
+            <summary>
+            Get the split index for a fraction word list, split index used to separate the numerator and the denominator.
+            Ex: A fraction is "three fifth", it will be joined as a list which 1st item is "three" and 2nd item is "fifth", the split index is 1 (index of fifth).
+            Ex: A fraction is "two and fifty-four hundredths", the split index is 3 (index of hundredths).
+            </summary>
+            <param name="fracWords">fraction words list.</param>
+            <returns>split index.</returns>
+        </member>
         <member name="M:Microsoft.Recognizers.Text.Number.INumberParserConfiguration.NormalizeTokenSet(System.Collections.Generic.IEnumerable{System.String},Microsoft.Recognizers.Text.ParseResult)">
             <summary>
             Used when requiring to normalize a token to a valid expression supported by the ImmutableDictionaries (language dictionaries).

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -934,7 +934,14 @@ namespace Microsoft.Recognizers.Text.Number
             return ret;
         }
 
-        protected int GetSplitIndex(List<string> fracWords)
+        /// <summary>
+        /// Get the split index for a fraction word list, split index used to separate the numerator and the denominator.
+        /// Ex: A fraction is "three fifth", it will be joined as a list which 1st item is "three" and 2nd item is "fifth", the split index is 1 (index of fifth).
+        /// Ex: A fraction is "two and fifty-four hundredths", the split index is 3 (index of hundredths).
+        /// </summary>
+        /// <param name="fracWords">fraction words list.</param>
+        /// <returns>split index.</returns>
+        private int GetSplitIndex(List<string> fracWords)
         {
             var splitIndex = fracWords.Count - 1;
             var currentValue = Config.ResolveCompositeNumber(fracWords[splitIndex]);
@@ -952,11 +959,10 @@ namespace Microsoft.Recognizers.Text.Number
 
                 var hundredsSM = 100;
 
-                // Below flag isUncomposobleWithSeparator is used to handle one existing bug for handling fraction input like "two and fifty-four hundredths".
-                // In the old code logic, when the loop comes to index=0 (text "two" in the input),
-                // since "two" and "fifty-four" is not composable, then it will not meet if condition below and starts to run the code after if block.
-                // It will run splitIndex++ and break, so the return index is 1 and it leads to it calculates the value as 2/(54*100)=0.003703...
-                // The right splitIndex should be 3 (text "hundredths" in the input) and the correct value should be 2 + 54/100 = 2.54.
+                // Below flag isUncomposobleWithSeparator is used to handle one scenario for handling fraction input like "two and fifty-four hundredths".
+                // Generally, when two numbers are not compsable, like "two" and "fifty-four", it will return the splitIndex as 1 (index of "fifty-four").
+                // But in this scenario, there is a separator "and" between "two" and "fifty-four" which means that the "two" is integer part and "fifty-four hundredths" is the fraction part.
+                // The splitIndex should be 3 (index of "hundredths") then.
                 bool isUncomposobleWithSeparator = previousValue < hundredsSM && !IsComposable(currentValue, previousValue) &&
                     Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex + 1]);
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -392,80 +392,15 @@ namespace Microsoft.Recognizers.Text.Number
 
                 var fracWords = Config.NormalizeTokenSet(resultText.Split(null), result).ToList();
 
-                // Split fraction with integer
-                var splitIndex = fracWords.Count - 1;
-                var currentValue = Config.ResolveCompositeNumber(fracWords[splitIndex]);
-                long roundValue = 1;
-
                 // For case like "half"
                 if (fracWords.Count == 1)
                 {
-                   result.Value = (1 / GetIntValue(fracWords)) * multiplier;
-                   return result;
+                    result.Value = (1 / GetIntValue(fracWords)) * multiplier;
+                    return result;
                 }
 
-                for (splitIndex = fracWords.Count - 2; splitIndex >= 0; splitIndex--)
-                {
-                    if (Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex]) ||
-                        Config.WrittenIntegerSeparatorTexts.Contains(fracWords[splitIndex]))
-                    {
-                        continue;
-                    }
-
-                    var previousValue = currentValue;
-                    currentValue = Config.ResolveCompositeNumber(fracWords[splitIndex]);
-
-                    var hundredsSM = 100;
-
-                    // Previous : hundred
-                    // Current : one
-                    if ((previousValue >= hundredsSM && previousValue > currentValue) ||
-                        (previousValue < hundredsSM && IsComposable(currentValue, previousValue)))
-                    {
-                        if (previousValue < hundredsSM && currentValue >= roundValue)
-                        {
-                            roundValue = currentValue;
-                        }
-                        else if (previousValue < hundredsSM && currentValue < roundValue)
-                        {
-                            splitIndex++;
-                            break;
-                        }
-
-                        // Current is the first word
-                        if (splitIndex == 0)
-                        {
-                            // Scan, skip the first word
-                            splitIndex = 1;
-                            while (splitIndex <= fracWords.Count - 2)
-                            {
-                                // e.g. one hundred thousand
-                                // frac[i+1] % 100 && frac[i] % 100 = 0
-                                if (Config.ResolveCompositeNumber(fracWords[splitIndex]) >= hundredsSM &&
-                                    !Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex + 1]) &&
-                                    Config.ResolveCompositeNumber(fracWords[splitIndex + 1]) < hundredsSM)
-                                {
-                                    splitIndex++;
-                                    break;
-                                }
-
-                                splitIndex++;
-                            }
-
-                            break;
-                        }
-
-                        continue;
-                    }
-
-                    splitIndex++;
-                    break;
-                }
-
-                if (splitIndex < 0)
-                {
-                    splitIndex = 0;
-                }
+                // Split fraction with integer
+                var splitIndex = this.GetSplitIndex(fracWords);
 
                 var fracPart = new List<string>();
                 for (var i = splitIndex; i < fracWords.Count; i++)
@@ -997,6 +932,85 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             return ret;
+        }
+
+        protected int GetSplitIndex(List<string> fracWords)
+        {
+            var splitIndex = fracWords.Count - 1;
+            var currentValue = Config.ResolveCompositeNumber(fracWords[splitIndex]);
+            long roundValue = 1;
+            for (splitIndex = fracWords.Count - 2; splitIndex >= 0; splitIndex--)
+            {
+                if (Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex]) ||
+                    Config.WrittenIntegerSeparatorTexts.Contains(fracWords[splitIndex]))
+                {
+                    continue;
+                }
+
+                var previousValue = currentValue;
+                currentValue = Config.ResolveCompositeNumber(fracWords[splitIndex]);
+
+                var hundredsSM = 100;
+
+                // Below flag isUncomposobleWithSeparator is used to handle one existing bug for handling fraction input like "two and fifty-four hundredths".
+                // In the old code logic, when the loop comes to index=0 (text "two" in the input),
+                // since "two" and "fifty-four" is not composable, then it will not meet if condition below and starts to run the code after if block.
+                // It will run splitIndex++ and break, so the return index is 1 and it leads to it calculates the value as 2/(54*100)=0.003703...
+                // The right splitIndex should be 3 (text "hundredths" in the input) and the correct value should be 2 + 54/100 = 2.54.
+                bool isUncomposobleWithSeparator = previousValue < hundredsSM && !IsComposable(currentValue, previousValue) &&
+                    Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex + 1]);
+
+                // Previous : hundred
+                // Current : one
+                if ((previousValue >= hundredsSM && previousValue > currentValue) ||
+                    (previousValue < hundredsSM && IsComposable(currentValue, previousValue)) || isUncomposobleWithSeparator)
+                {
+                    if (previousValue < hundredsSM && currentValue >= roundValue)
+                    {
+                        roundValue = currentValue;
+                    }
+                    else if (previousValue < hundredsSM && currentValue < roundValue)
+                    {
+                        splitIndex++;
+                        break;
+                    }
+
+                    // Current is the first word
+                    if (splitIndex == 0)
+                    {
+                        // Scan, skip the first word
+                        splitIndex = 1;
+                        while (splitIndex <= fracWords.Count - 2)
+                        {
+                            // e.g. one hundred thousand
+                            // frac[i+1] % 100 && frac[i] % 100 = 0
+                            if (Config.ResolveCompositeNumber(fracWords[splitIndex]) >= hundredsSM &&
+                                !Config.WrittenFractionSeparatorTexts.Contains(fracWords[splitIndex + 1]) &&
+                                Config.ResolveCompositeNumber(fracWords[splitIndex + 1]) < hundredsSM)
+                            {
+                                splitIndex++;
+                                break;
+                            }
+
+                            splitIndex++;
+                        }
+
+                        break;
+                    }
+
+                    continue;
+                }
+
+                splitIndex++;
+                break;
+            }
+
+            if (splitIndex < 0)
+            {
+                splitIndex = 0;
+            }
+
+            return splitIndex;
         }
 
         private Regex BuildTextNumberRegex()

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -1129,6 +1129,38 @@
     ]
   },
   {
+    "Input": "two and fifty-four hundredths",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two and fifty-four hundredths",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "2.54"
+        },
+        "Start": 0,
+        "End": 28
+      }
+    ]
+  },
+  {
+    "Input": "two hundred and fifty-four hundredths",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two hundred and fifty-four hundredths",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "200.54"
+        },
+        "Start": 0,
+        "End": 36
+      }
+    ]
+  },
+  {
     "Input": "1.1^+23",
     "Results": [
       {
@@ -2973,7 +3005,7 @@
           "value": "10000000000"
         }
       },
-	  {
+      {
         "Text": "10 tln",
         "TypeName": "number",
         "Start": 17,

--- a/Specs/Number/English/NumberModelExperimentalMode.json
+++ b/Specs/Number/English/NumberModelExperimentalMode.json
@@ -1173,6 +1173,38 @@
     ]
   },
   {
+    "Input": "two and fifty-four hundredths",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two and fifty-four hundredths",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "2.54"
+        },
+        "Start": 0,
+        "End": 28
+      }
+    ]
+  },
+  {
+    "Input": "two hundred and fifty-four hundredths",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two hundred and fifty-four hundredths",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "200.54"
+        },
+        "Start": 0,
+        "End": 36
+      }
+    ]
+  },
+  {
     "Input": "1.1^+23",
     "NotSupported": "javascript, java, python",
     "Results": [


### PR DESCRIPTION
Fix wrong resolution for some fractions, scenario as below.
“two hundred and fifty-four hundredths” -> 200.54 (correctly found)
“two and fifty-four hundredths” -> 0.0037037037… (it calculates (2 / 54) div by 100) instead of 2.54