### PR TITLE
Fix 2 years ago in French not recognized

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>({ThisPrefixRegex}\s+mois)|(mois\s+{PastSuffixRegex})|(mois\s+{NextSuffixRegex}))\b";
       public const string WrittenMonthRegex = @"(?<month>avril|avr(\.)?|ao[uû]t|d[eé]cembre|d[eé]c(\.)?|f[eé]vrier|f[eé]vr?(\.)?|janvier|janv?(\.)?|juillet|jui?[ln](\.)?|mars?(\.)?|mai|novembre|nov(\.)?|octobre|oct(\.)?|septembre|sept?(\.)?(?!\s+heures))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>(en\s*|le\s*|de\s*|dans\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
-      public const string DateUnitRegex = @"(?<unit>an(s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b";
+      public const string DateUnitRegex = @"(?<unit>an(?<plural>s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b";
       public static readonly string SimpleCasesRegex = $@"\b((d[ue])|entre\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b((d[ue]|entre)\s+)?{MonthSuffixRegex}\s+((d[ue]|entre)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(entre|d[ue]\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
@@ -210,7 +210,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string AroundRegex = @"\b(vers|à\s+peu\s+près|environ)\b";
       public const string AgoPrefixRegex = @"\b(y a)\b";
       public const string LaterRegex = @"\b(plus\s+tard|à\s+partir\s+(de\s+(maintenant|demain)|d'aujourd'hui)|après\s+(aujourd'hui|demain))\b";
-      public static readonly string AgoRegex = $@"\b((depuis|il\s+y\s*a)(\s+{AroundRegex})?|auparavant|avant\s+(?<day>hier|aujourd'hui))\b";
+      public static readonly string AgoRegex = $@"\b((il\s+y\s*a)(\s+{AroundRegex})?|auparavant|avant\s+(?<day>hier|aujourd'hui))\b";
       public const string BeforeAfterRegex = @"^\b$";
       public const string InConnectorRegex = @"\b(dans|en)\b";
       public const string SinceYearSuffixRegex = @"^\b$";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>({ThisPrefixRegex}\s+mois)|(mois\s+{PastSuffixRegex})|(mois\s+{NextSuffixRegex}))\b";
       public const string WrittenMonthRegex = @"(?<month>avril|avr(\.)?|ao[uû]t|d[eé]cembre|d[eé]c(\.)?|f[eé]vrier|f[eé]vr?(\.)?|janvier|janv?(\.)?|juillet|jui?[ln](\.)?|mars?(\.)?|mai|novembre|nov(\.)?|octobre|oct(\.)?|septembre|sept?(\.)?(?!\s+heures))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>(en\s*|le\s*|de\s*|dans\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
-      public const string DateUnitRegex = @"(?<unit>an|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b";
+      public const string DateUnitRegex = @"(?<unit>an(s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b";
       public static readonly string SimpleCasesRegex = $@"\b((d[ue])|entre\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b((d[ue]|entre)\s+)?{MonthSuffixRegex}\s+((d[ue]|entre)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(entre|d[ue]\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
@@ -212,7 +212,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string LaterRegex = @"\b(plus\s+tard|à\s+partir\s+(de\s+(maintenant|demain)|d'aujourd'hui)|après\s+(aujourd'hui|demain))\b";
       public static readonly string AgoRegex = $@"\b((depuis|il\s+y\s*a)(\s+{AroundRegex})?|auparavant|avant\s+(?<day>hier|aujourd'hui))\b";
       public const string BeforeAfterRegex = @"^\b$";
-      public const string InConnectorRegex = @"\b(dans|en|sur)\b";
+      public const string InConnectorRegex = @"\b(dans|en)\b";
       public const string SinceYearSuffixRegex = @"^\b$";
       public const string WithinNextPrefixRegex = @"\b(dans\s+les)\b";
       public const string TodayNowRegex = @"\b(aujourd'hui|maintenant)\b";

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -76,7 +76,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>(en\s*|le\s*|de\s*|dans\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>an(s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b
+  def: (?<unit>an(?<plural>s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b
 SimpleCasesRegex: !nestedRegex
   def: \b((d[ue])|entre\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex ]
@@ -479,7 +479,7 @@ AgoPrefixRegex: !simpleRegex
 LaterRegex: !simpleRegex
   def: \b(plus\s+tard|à\s+partir\s+(de\s+(maintenant|demain)|d'aujourd'hui)|après\s+(aujourd'hui|demain))\b
 AgoRegex: !nestedRegex
-  def: \b((depuis|il\s+y\s*a)(\s+{AroundRegex})?|auparavant|avant\s+(?<day>hier|aujourd'hui))\b
+  def: \b((il\s+y\s*a)(\s+{AroundRegex})?|auparavant|avant\s+(?<day>hier|aujourd'hui))\b
   references: [ AroundRegex ]
 BeforeAfterRegex: !simpleRegex
   def: ^\b$

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -76,7 +76,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>(en\s*|le\s*|de\s*|dans\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>an|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b
+  def: (?<unit>an(s)?|(?<plural>mois)|((l')?ann[eé]e|semaine|journ[eé]e|jour)(?<plural>s)?)\b
 SimpleCasesRegex: !nestedRegex
   def: \b((d[ue])|entre\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex ]
@@ -484,7 +484,7 @@ AgoRegex: !nestedRegex
 BeforeAfterRegex: !simpleRegex
   def: ^\b$
 InConnectorRegex: !simpleRegex
-  def: \b(dans|en|sur)\b
+  def: \b(dans|en)\b
 SinceYearSuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^\b$

--- a/Specs/DateTime/French/DateExtractor.json
+++ b/Specs/DateTime/French/DateExtractor.json
@@ -2212,6 +2212,30 @@
     ]
   },
   {
+    "Input": "il y a deux ans",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "il y a deux ans",
+        "Type": "date",
+        "Start": 0,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "dans trois ans",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "dans trois ans",
+        "Type": "date",
+        "Start": 0,
+        "Length": 14
+      }
+    ]
+  },
+  {
     "Input": "je vais partir d'ici 2 ans et 21 jours plus tard",
     "NotSupported": "dotnet, javascript, python, java",
     "Results": [

--- a/Specs/DateTime/French/DateParser.json
+++ b/Specs/DateTime/French/DateParser.json
@@ -3177,7 +3177,10 @@
   },
   {
     "Input": "Je suis revenu il y a deux ans",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "il y a deux ans",
@@ -3193,6 +3196,30 @@
         },
         "Start": 15,
         "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Je reviendrai dans trois ans",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "dans trois ans",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-11-07",
+          "FutureResolution": {
+            "date": "2019-11-07"
+          },
+          "PastResolution": {
+            "date": "2019-11-07"
+          }
+        },
+        "Start": 14,
+        "Length": 14
       }
     ]
   },

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -8720,20 +8720,71 @@
     ]
   },
   {
-    "Input": "bonjour la maison n'est plus habitée depuis ans",
+    "Input": "bonjour la maison n'est plus habitée depuis 3 ans",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "depuis ans",
+        "Text": "depuis 3 ans",
         "Start": 37,
-        "End": 46,
-        "TypeName": "datetimeV2.duration",
+        "End": 48,
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "P1Y",
-              "Mod": "since",
-              "type": "duration",
-              "value": "31536000"
+              "timex": "2013-11-07",
+              "type": "date",
+              "value": "2013-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je suis revenu il y a deux ans",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "il y a deux ans",
+        "Start": 15,
+        "End": 29,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014-11-07",
+              "type": "date",
+              "value": "2014-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je reviendrai dans trois ans",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "dans trois ans",
+        "Start": 14,
+        "End": 27,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-11-07",
+              "type": "date",
+              "value": "2019-11-07"
             }
           ]
         }

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -8720,23 +8720,23 @@
     ]
   },
   {
-    "Input": "bonjour la maison n'est plus habitée depuis 3 ans",
+    "Input": "bonjour la maison n'est plus habitée depuis 6 ans",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "depuis 3 ans",
+        "Text": "depuis 6 ans",
         "Start": 37,
         "End": 48,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2013-11-07",
+              "timex": "2010-11-07",
               "type": "date",
-              "value": "2013-11-07"
+              "value": "2010-11-07"
             }
           ]
         }

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -8742,21 +8742,21 @@
     ]
   },
   {
-    "Input": "bonjour la maison n'est plus habitée depuis 3 ans",
+    "Input": "bonjour la maison n'est plus habitée depuis 2 ans",
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "depuis 3 ans",
+        "Text": "depuis 2 ans",
         "Start": 37,
         "End": 48,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "P3Y",
+              "timex": "P2Y",
               "Mod": "since",
               "type": "duration",
-              "value": "94608000"
+              "value": "63072000"
             }
           ]
         }

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -8720,23 +8720,65 @@
     ]
   },
   {
-    "Input": "bonjour la maison n'est plus habitée depuis 6 ans",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
+    "Input": "J'ai une voiture depuis 3 ans",
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "depuis 6 ans",
-        "Start": 37,
-        "End": 48,
-        "TypeName": "datetimeV2.date",
+        "Text": "depuis 3 ans",
+        "Start": 17,
+        "End": 28,
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "2010-11-07",
-              "type": "date",
-              "value": "2010-11-07"
+              "timex": "P3Y",
+              "Mod": "since",
+              "type": "duration",
+              "value": "94608000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "bonjour la maison n'est plus habitée depuis 3 ans",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "depuis 3 ans",
+        "Start": 37,
+        "End": 48,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3Y",
+              "Mod": "since",
+              "type": "duration",
+              "value": "94608000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "bonjour la maison n'est plus habitée depuis 1 an",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "depuis 1 an",
+        "Start": 37,
+        "End": 47,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1Y",
+              "Mod": "since",
+              "type": "duration",
+              "value": "31536000"
             }
           ]
         }
@@ -21107,13 +21149,14 @@
         "Text": "depuis trois semaines",
         "Start": 13,
         "End": 33,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "2021-04-29",
-              "type": "date",
-              "value": "2021-04-29"
+              "timex": "P3W",
+              "Mod": "since",
+              "type": "duration",
+              "value": "1814400"
             }
           ]
         }


### PR DESCRIPTION
Fix 2 years ago in French not recognized.
"il y a deux ans" e.g. "two years ago" is not being detected in French.