### PR TITLE
Fix 2 Python syntax warnings

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -656,7 +656,7 @@ class MatchingUtil:
     def pre_process_text_remove_superfluous_words(text: str, matcher: Pattern):
         superfluous_word_matches = MatchingUtil.remove_sub_matches(matcher.find(text))
 
-        bias = 0[0]
+        bias = 0
 
         for match in superfluous_word_matches:
             text = text[match.start - bias: match.length]

--- a/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/extractors.py
@@ -38,7 +38,7 @@ class BaseNumberExtractor(Extractor):
         pass
 
     def extract(self, source: str) -> List[ExtractResult]:
-        if source is None or len(source.strip()) is 0:
+        if source is None or len(source.strip()) == 0:
             return list()
         result: List[ExtractResult] = list()
         match_source = dict()


### PR DESCRIPTION
Fix 2 Python syntax warnings as below.

/usr/local/lib/python3.10/site-packages/recognizers_date_time/date_time/utilities.py:552: SyntaxWarning: 'int' object is not subscriptable; perhaps you missed a comma?
bias = 0[0]

/usr/local/lib/python3.10/site-packages/recognizers_number/number/extractors.py:37: SyntaxWarning: "is" with a literal. Did you mean "=="?
if source is None or len(source.strip()) is 0: