### PR TITLE
Support French number sub type

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Text.Number
             Constants.SPANISH,
             Constants.SWEDISH,
             Constants.KOREAN,
+            Constants.FRENCH,
 
             // TODO: Temporarily disabled as existing TestSpec not supporting
             // Constants.JAPANESE_SUBS,

--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -6,6 +6,7 @@
         "Text": "un cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,2"
         },
         "Start": 0,
@@ -20,6 +21,7 @@
         "Text": "un demi",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,5"
         },
         "Start": 0,
@@ -34,6 +36,7 @@
         "Text": "un billionieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1E-12"
         },
         "Start": 0,
@@ -48,6 +51,7 @@
         "Text": "cent mille billionieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1E-07"
         },
         "Start": 0,
@@ -62,6 +66,7 @@
         "Text": "trois cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,6"
         },
         "Start": 0,
@@ -76,6 +81,7 @@
         "Text": "un vingt cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,04"
         },
         "Start": 0,
@@ -90,6 +96,7 @@
         "Text": "trois et un cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "3,2"
         },
         "Start": 0,
@@ -104,6 +111,7 @@
         "Text": "vingt et un cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "20,2"
         },
         "Start": 0,
@@ -118,6 +126,7 @@
         "Text": "une vingt et unieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,0476190476190476"
         },
         "Start": 0,
@@ -132,6 +141,7 @@
         "Text": "un vingt-cinquieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,04"
         },
         "Start": 0,
@@ -146,6 +156,7 @@
         "Text": "un sur trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,333333333333333"
         },
         "Start": 0,
@@ -160,6 +171,7 @@
         "Text": "1 sur vingt-un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,0476190476190476"
         },
         "Start": 0,
@@ -174,6 +186,7 @@
         "Text": "1 sur cent vingt et un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,00826446280991736"
         },
         "Start": 0,
@@ -188,6 +201,7 @@
         "Text": "1 sur trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,333333333333333"
         },
         "Start": 0,
@@ -202,6 +216,7 @@
         "Text": "1 sur 3",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,333333333333333"
         },
         "Start": 0,
@@ -216,6 +231,7 @@
         "Text": "un sur 3",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,333333333333333"
         },
         "Start": 0,
@@ -230,6 +246,7 @@
         "Text": "un sur 20",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,05"
         },
         "Start": 0,
@@ -244,6 +261,7 @@
         "Text": "un sur cent",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,01"
         },
         "Start": 0,
@@ -258,6 +276,7 @@
         "Text": "un sur cent vingt cinq",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,008"
         },
         "Start": 0,
@@ -272,6 +291,7 @@
         "Text": "cent trente cinquiemes",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "26"
         },
         "Start": 0,
@@ -286,6 +306,7 @@
         "Text": "192",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "192"
         },
         "Start": 0,
@@ -300,6 +321,7 @@
         "Text": "192.168",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "192168"
         },
         "Start": 0,
@@ -309,6 +331,7 @@
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 8,
@@ -318,6 +341,7 @@
         "Text": "2",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2"
         },
         "Start": 10,
@@ -344,6 +368,7 @@
         "Text": "9,2321312",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "9,2321312"
         },
         "Start": 0,
@@ -358,6 +383,7 @@
         "Text": "-9,2321312",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "-9,2321312"
         },
         "Start": 1,
@@ -372,6 +398,7 @@
         "Text": "vingt",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "20"
         },
         "Start": 0,
@@ -386,6 +413,7 @@
         "Text": "cent",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "100"
         },
         "Start": 0,
@@ -400,6 +428,7 @@
         "Text": ",08",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "0,08"
         },
         "Start": 0,
@@ -414,6 +443,7 @@
         "Text": "vingt quatre",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "24"
         },
         "Start": 0,
@@ -428,6 +458,7 @@
         "Text": "vingt-quatre",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "24"
         },
         "Start": 0,
@@ -442,6 +473,7 @@
         "Text": "trente trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "33"
         },
         "Start": 0,
@@ -456,6 +488,7 @@
         "Text": "trente-trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "33"
         },
         "Start": 0,
@@ -470,6 +503,7 @@
         "Text": "dix-sept",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "17"
         },
         "Start": 0,
@@ -484,6 +518,7 @@
         "Text": "dix sept",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "17"
         },
         "Start": 0,
@@ -498,6 +533,7 @@
         "Text": "nonante",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "90"
         },
         "Start": 0,
@@ -512,6 +548,7 @@
         "Text": "trois million",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3000000"
         },
         "Start": 0,
@@ -526,6 +563,7 @@
         "Text": "trois million sept",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3000007"
         },
         "Start": 0,
@@ -540,6 +578,7 @@
         "Text": ",23456000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "0,23456"
         },
         "Start": 0,
@@ -554,6 +593,7 @@
         "Text": "4,800",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "4,8"
         },
         "Start": 0,
@@ -568,6 +608,7 @@
         "Text": "cent trois et deux tiers",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "103,666666666667"
         },
         "Start": 0,
@@ -582,6 +623,7 @@
         "Text": "seize",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "16"
         },
         "Start": 0,
@@ -596,6 +638,7 @@
         "Text": "deux tiers",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,666666666666667"
         },
         "Start": 0,
@@ -610,6 +653,7 @@
         "Text": "cent six",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "106"
         },
         "Start": 0,
@@ -624,6 +668,7 @@
         "Text": "cinq cent trente cinq",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "535"
         },
         "Start": 0,
@@ -638,6 +683,7 @@
         "Text": "soixante et un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "61"
         },
         "Start": 0,
@@ -652,6 +698,7 @@
         "Text": "3 douzaines",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "36"
         },
         "Start": 1,
@@ -666,6 +713,7 @@
         "Text": "2 douzaine",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "24"
         },
         "Start": 0,
@@ -680,6 +728,7 @@
         "Text": "trois cent douze",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "312"
         },
         "Start": 1,
@@ -694,6 +743,7 @@
         "Text": "trois cent vingt quatre",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "324"
         },
         "Start": 0,
@@ -708,6 +758,7 @@
         "Text": "cent seize",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "116"
         },
         "Start": 0,
@@ -722,6 +773,7 @@
         "Text": "322 cent",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "32200"
         },
         "Start": 1,
@@ -736,6 +788,7 @@
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 0,
@@ -745,6 +798,7 @@
         "Text": "234",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "234"
         },
         "Start": 3,
@@ -754,6 +808,7 @@
         "Text": "567",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "567"
         },
         "Start": 8,
@@ -768,6 +823,7 @@
         "Text": "-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-1"
         },
         "Start": 1,
@@ -782,6 +838,7 @@
         "Text": "-4/5",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-0,8"
         },
         "Start": 0,
@@ -796,6 +853,7 @@
         "Text": "- 1 4/5",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-1,8"
         },
         "Start": 0,
@@ -810,6 +868,7 @@
         "Text": "trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3"
         },
         "Start": 0,
@@ -824,6 +883,7 @@
         "Text": "123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "123456789101231"
         },
         "Start": 1,
@@ -838,6 +898,7 @@
         "Text": "-123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-123456789101231"
         },
         "Start": 0,
@@ -852,6 +913,7 @@
         "Text": "-123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-123456789101231"
         },
         "Start": 1,
@@ -866,6 +928,7 @@
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 0,
@@ -880,6 +943,7 @@
         "Text": "10k",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "10000"
         },
         "Start": 0,
@@ -894,6 +958,7 @@
         "Text": "10g",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "10000000000"
         },
         "Start": 0,
@@ -908,6 +973,7 @@
         "Text": "- 10  k",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-10000"
         },
         "Start": 0,
@@ -922,6 +988,7 @@
         "Text": "2 million",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2000000"
         },
         "Start": 0,
@@ -936,6 +1003,7 @@
         "Text": "2 millions",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2000000"
         },
         "Start": 0,
@@ -950,6 +1018,7 @@
         "Text": "1 billion",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000000000000"
         },
         "Start": 0,
@@ -964,6 +1033,7 @@
         "Text": "1 billions",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000000000000"
         },
         "Start": 0,
@@ -978,6 +1048,7 @@
         "Text": "trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3"
         },
         "Start": 1,
@@ -992,6 +1063,7 @@
         "Text": "un billion",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000000000000"
         },
         "Start": 0,
@@ -1006,6 +1078,7 @@
         "Text": "un centieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,01"
         },
         "Start": 0,
@@ -1020,6 +1093,7 @@
         "Text": "1,1^+23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "8,95430243255239"
         },
         "Start": 0,
@@ -1034,6 +1108,7 @@
         "Text": "2,5^-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "0,4"
         },
         "Start": 0,
@@ -1048,6 +1123,7 @@
         "Text": "-1,1^+23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-8,95430243255239"
         },
         "Start": 0,
@@ -1062,6 +1138,7 @@
         "Text": "-2,5^-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-0,4"
         },
         "Start": 0,
@@ -1076,6 +1153,7 @@
         "Text": "2  1/4",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "2,25"
         },
         "Start": 0,
@@ -1090,6 +1168,7 @@
         "Text": "3/4",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,75"
         },
         "Start": 0,
@@ -1104,6 +1183,7 @@
         "Text": "-1,1^--23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-8,95430243255239"
         },
         "Start": 0,
@@ -1118,6 +1198,7 @@
         "Text": "-127,32e13",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-1,2732E+15"
         },
         "Start": 0,
@@ -1132,6 +1213,7 @@
         "Text": "12,32e+14",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "1,232E+15"
         },
         "Start": 0,
@@ -1146,6 +1228,7 @@
         "Text": "-12e-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-1,2"
         },
         "Start": 0,
@@ -1160,6 +1243,7 @@
         "Text": "1e10",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "10000000000"
         },
         "Start": 0,
@@ -1174,6 +1258,7 @@
         "Text": "1,1^23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "8,95430243255239"
         },
         "Start": 0,
@@ -1188,6 +1273,7 @@
         "Text": "cent et trois quarts",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "100,75"
         },
         "Start": 0,
@@ -1202,6 +1288,7 @@
         "Text": "deux cent deux mille",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "202000"
         },
         "Start": 0,
@@ -1216,6 +1303,7 @@
         "Text": "trois cent trente et un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "331"
         },
         "Start": 0,
@@ -1230,6 +1318,7 @@
         "Text": "soixante-dix",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "70"
         },
         "Start": 0,
@@ -1244,6 +1333,7 @@
         "Text": "trois quarts",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,75"
         },
         "Start": 0,
@@ -1258,6 +1348,7 @@
         "Text": "vingt et trois cinquiemes",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "20,6"
         },
         "Start": 0,
@@ -1272,6 +1363,7 @@
         "Text": "un huitieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,125"
         },
         "Start": 0,
@@ -1286,6 +1378,7 @@
         "Text": "cinq huitieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,625"
         },
         "Start": 0,
@@ -1300,6 +1393,7 @@
         "Text": "2,33 k",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "2330"
         },
         "Start": 0,
@@ -1314,6 +1408,7 @@
         "Text": "vingt-trois cinquiemes",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "4,6"
         },
         "Start": 0,
@@ -1328,6 +1423,7 @@
         "Text": "un et un demi",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1,5"
         },
         "Start": 0,
@@ -1342,6 +1438,7 @@
         "Text": "un et un quatrieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1,25"
         },
         "Start": 0,
@@ -1356,6 +1453,7 @@
         "Text": "cinq et un quart",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "5,25"
         },
         "Start": 0,
@@ -1370,6 +1468,7 @@
         "Text": "cinquante-deux",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "52"
         },
         "Start": 0,
@@ -1384,6 +1483,7 @@
         "Text": "cinquante  deux",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "52"
         },
         "Start": 0,
@@ -1398,6 +1498,7 @@
         "Text": "vingt et trois et trois cinquiemes",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "23,6"
         },
         "Start": 0,
@@ -1412,6 +1513,7 @@
         "Text": "deux  cent  deux  mille",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "202000"
         },
         "Start": 0,
@@ -1426,6 +1528,7 @@
         "Text": "deux cent virgule trois",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "200,3"
         },
         "Start": 0,
@@ -1440,6 +1543,7 @@
         "Text": "deux cent virgule cinquante deux",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "200,52"
         },
         "Start": 0,
@@ -1454,6 +1558,7 @@
         "Text": "1 234 567",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1234567"
         },
         "Start": 0,
@@ -1468,6 +1573,7 @@
         "Text": "40 000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "40000"
         },
         "Start": 0,
@@ -1477,6 +1583,7 @@
         "Text": "40 000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "40000"
         },
         "Start": 23,
@@ -1491,6 +1598,7 @@
         "Text": "1 414 021 100",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1414021100"
         },
         "Start": 49,
@@ -1506,6 +1614,7 @@
         "Text": "423",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "423"
         },
         "Start": 0,
@@ -1515,6 +1624,7 @@
         "Text": "0000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "0"
         },
         "Start": 4,
@@ -1524,6 +1634,7 @@
         "Text": "deux",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2"
         },
         "Start": 31,
@@ -1538,6 +1649,7 @@
         "Text": "1 234 567,89",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "1234567,89"
         },
         "Start": 0,
@@ -1547,6 +1659,7 @@
         "Text": "un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 17,
@@ -1561,6 +1674,7 @@
         "Text": "quatre-vingt-quinze",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "95"
         },
         "Start": 0,
@@ -1575,6 +1689,7 @@
         "Text": "quatre-vingt",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "80"
         },
         "Start": 0,
@@ -1589,6 +1704,7 @@
         "Text": "quatre-vingt-quinze",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "95"
         },
         "Start": 0,
@@ -1598,6 +1714,7 @@
         "Text": "quatre-vingt",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "80"
         },
         "Start": 21,
@@ -1607,6 +1724,7 @@
         "Text": "quatre-vingt-dix-neuf",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "99"
         },
         "Start": 35,
@@ -1616,6 +1734,7 @@
         "Text": "quatre-vingt-dix neuf",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "99"
         },
         "Start": 58,
@@ -1625,6 +1744,7 @@
         "Text": "quatre vingt dix neuf",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "99"
         },
         "Start": 81,
@@ -1634,6 +1754,7 @@
         "Text": "quatre-vingts",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "80"
         },
         "Start": 104,
@@ -1648,6 +1769,7 @@
         "Text": "neuf mille neuf cent quatre-vingt-dix neuf",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "9999"
         },
         "Start": 0,
@@ -1664,6 +1786,7 @@
         "End": 9,
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         }
       },
@@ -1673,6 +1796,7 @@
         "End": 25,
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000"
         }
       },
@@ -1682,6 +1806,7 @@
         "End": 31,
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3"
         }
       }
@@ -1694,6 +1819,7 @@
         "Text": "un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 17,
@@ -1708,6 +1834,7 @@
         "Text": "vingt et un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "21"
         },
         "Start": 0,
@@ -1722,6 +1849,7 @@
         "Text": "vingt et un",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "21"
         },
         "Start": 0,
@@ -1731,6 +1859,7 @@
         "Text": "vingt-deux",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "22"
         },
         "Start": 15,
@@ -1745,6 +1874,7 @@
         "Text": "quatre centièmes",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,04"
         },
         "Start": 0,
@@ -1759,6 +1889,7 @@
         "Text": "une",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         },
         "Start": 3,
@@ -1773,6 +1904,7 @@
         "Text": "un vingt et unieme",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,0476190476190476"
         },
         "Start": 0,
@@ -1787,6 +1919,7 @@
         "Text": "une douzaine",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "12"
         },
         "Start": 1,
@@ -1801,6 +1934,7 @@
         "Text": "trois douzaines",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "36"
         },
         "Start": 1,
@@ -1816,6 +1950,7 @@
         "Text": "⅙",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,166666666666667"
         },
         "Start": 16,
@@ -1825,6 +1960,7 @@
         "Text": "½",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0,5"
         },
         "Start": 29,
@@ -4281,6 +4417,7 @@
         "Text": "zéro",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "0"
         },
         "Start": 3,
@@ -4290,6 +4427,7 @@
         "Text": "dix",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "10"
         },
         "Start": 10,
@@ -4305,9 +4443,10 @@
         "Text": "un demi-million",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "500000",
-        "Start": 0,
-        "End": 14
+          "Start": 0,
+          "End": 14
         }
       }
     ]
@@ -4320,9 +4459,10 @@
         "Text": "un million et demi",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1500000",
-        "Start": 7,
-        "End": 24
+          "Start": 7,
+          "End": 24
         }
       }
     ]
@@ -4335,9 +4475,10 @@
         "Text": "3 millions et demi",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "3500000",
-        "Start": 21,
-        "End": 38
+          "Start": 21,
+          "End": 38
         }
       }
     ]
@@ -4350,9 +4491,10 @@
         "Text": "un milliard et demi million",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1000500000",
-        "Start": 25,
-        "End": 51
+          "Start": 25,
+          "End": 51
         }
       }
     ]
@@ -4365,6 +4507,7 @@
         "Text": "cinq milliards et trois quarts",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "5750000000"
         },
         "Start": 17,
@@ -4380,6 +4523,7 @@
         "Text": "six millions et deux tiers",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "6666666,66666667"
         },
         "Start": 12,


### PR DESCRIPTION
Add support for French number sub type in resolution as below.

"Results": [
  {
    "Text": "3",
    "TypeName": "number",
    "Resolution": {
      **"subtype": "integer",**
      "value": "3"
    },
    "Start": 0,
    "End": 1
  }
