### PR TITLE
[DE DateTimeV2] Fix occasionally NullReferenceException in German DateTimeModel test when input is tag der Arbeit

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/HolidayParserGer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/HolidayParserGer.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 { "stgeorgeday", StGeorgeDay },
                 { "mayday", Mayday },
                 { "labour", LaborDay },
+                { "laborday", LaborDay },
                 { "cincodemayoday", CincoDeMayo },
                 { "baptisteday", BaptisteDay },
                 { "usindependenceday", UsaIndependenceDay },


### PR DESCRIPTION
Fix occasionally NullReferenceException in German DateTimeModel test when input is tag der Arbeit, the test and message as below.

Test:
Microsoft.Recognizers.Text.DateTime.Tests.TestDateTime_German DateTimeModel 

Message: 
Test method Microsoft.Recognizers.Text.DateTime.Tests.TestDateTime_German.DateTimeModel threw exception: 
System.ApplicationException: Input: "Tag der Arbeit, ersten Weihnachtsfeiertag, zweiten Weihnachtstag" ---> System.NullReferenceException: Object reference not set to an instance of an object.




