### PR TITLE
[ZH DateTimeV2] Support Chinese week day after/before two weeks, the week/weekend before last

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string DateThisRegex = $@"(这个|这一个|这|这一|本){WeekDayRegex}";
       public static readonly string DateLastRegex = $@"(上一个|上个|上一|上|最后一个|最后)(的)?{WeekDayRegex}";
       public static readonly string DateNextRegex = $@"(下一个|下个|下一|下)(的)?{WeekDayRegex}";
+      public static readonly string DateNextNextRegex = $@"(下下|下下[个個]){WeekDayRegex}";
+      public static readonly string DateLastLastRegex = $@"(上上|上上[个個]){WeekDayRegex}";
       public const string WeekWithWeekDayRangeRegex = @"^[.]";
       public const string WoMLastRegex = @"最后一";
       public const string WoMPreviousRegex = @"上个";
@@ -78,7 +80,8 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string DatePeriodThisRegex = @"这个|这一个|这|这一|本";
       public const string DatePeriodLastRegex = @"上个|上一个|上|上一";
       public const string DatePeriodNextRegex = @"下个|下一个|下|下一";
-      public const string DatePeriodNextNextRegex = @"下下";
+      public const string DatePeriodNextNextRegex = @"下下|下下[个個]";
+      public const string DatePeriodLastLastRegex = @"上上|上上[个個]";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)";
       public const string HalfYearRegex = @"((?<firstHalf>(上|前)半年)|(?<secondHalf>(下|后)半年))";
       public static readonly string YearRegex = $@"(({YearNumRegex})(\s*年)?|({SimpleYearRegex})\s*年){HalfYearRegex}?";
@@ -90,7 +93,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string YearAndMonth = $@"({DatePeriodYearInCJKRegex}|{YearRegex}|(?<yearrel>明年|今年|去年))\s*({MonthRegex}|的?(?<cardinal>第一|第二|第三|第四|第五|第六|第七|第八|第九|第十|第十一|第十二|最后一)\s*个月\s*)";
       public static readonly string SimpleYearAndMonth = $@"({YearNumRegex}[/\\\-]{MonthNumRegex}\b$)";
       public static readonly string PureNumYearAndMonth = $@"({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})";
-      public static readonly string OneWordPeriodRegex = $@"(((?<yearrel>(明|今|去)年)\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextNextRegex}|{DatePeriodNextRegex})(?<halfTag>半)?\s*(周末|周|月|年)|周末|(今|明|去|前|后)年(\s*{HalfYearRegex})?)";
+      public static readonly string OneWordPeriodRegex = $@"(((?<yearrel>(明|今|去)年)\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastLastRegex}|{DatePeriodLastRegex}|{DatePeriodNextNextRegex}|{DatePeriodNextRegex})(?<halfTag>半)?\s*([周週]末|[周週]|月|年)|[周週]末|(今|明|去|前|后)年(\s*{HalfYearRegex})?)";
       public const string LaterEarlyPeriodRegex = @"^[.]";
       public const string DatePointWithAgoAndLater = @"^[.]";
       public static readonly string WeekOfMonthRegex = $@"(?<wom>{MonthSuffixRegex}的(?<cardinal>第一|第二|第三|第四|第五|最后一)\s*周\s*)";
@@ -286,7 +289,8 @@ namespace Microsoft.Recognizers.Definitions.Chinese
         };
       public static readonly IList<string> WeekendTerms = new List<string>
         {
-            @"周末"
+            @"周末",
+            @"週末"
         };
       public static readonly IList<string> WeekTerms = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DateNextRegex, RegexFlags, RegexTimeOut);
 
+        public static readonly Regex NextNextRegex = new Regex(DateTimeDefinitions.DateNextNextRegex, RegexFlags, RegexTimeOut);
+
+        public static readonly Regex LastLastRegex = new Regex(DateTimeDefinitions.DateLastLastRegex, RegexFlags, RegexTimeOut);
+
         public static readonly Regex SpecialDayRegex = new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags, RegexTimeOut);
 
         public static readonly Regex WeekDayOfMonthRegex = new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags, RegexTimeOut);
@@ -78,7 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             ImplicitDateList = new List<Regex>
             {
-                LunarRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
+                LunarRegex, SpecialDayRegex, ThisRegex, LastLastRegex, LastRegex, NextNextRegex, NextRegex,
                 WeekDayRegex, WeekDayOfMonthRegex, SpecialDate,
             };
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags, RegexTimeOut);
         public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DatePeriodLastRegex, RegexFlags, RegexTimeOut);
         public static readonly Regex NextNextRegex = new Regex(DateTimeDefinitions.DatePeriodNextNextRegex, RegexFlags, RegexTimeOut);
+        public static readonly Regex LastLastRegex = new Regex(DateTimeDefinitions.DatePeriodLastLastRegex, RegexFlags, RegexTimeOut);
         public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DatePeriodNextRegex, RegexFlags, RegexTimeOut);
         public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags, RegexTimeOut);
         public static readonly Regex LaterEarlyPeriodRegex = new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags, RegexTimeOut);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             WeekDayAndDayRegex = ChineseDateExtractorConfiguration.WeekDayAndDayRegex;
             DurationRelativeDurationUnitRegex = ChineseDateExtractorConfiguration.DurationRelativeDurationUnitRegex;
             SpecialDayWithNumRegex = ChineseDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextNextRegex = ChineseDateExtractorConfiguration.NextNextRegex;
+            LastLastRegex = ChineseDateExtractorConfiguration.LastLastRegex;
 
             CardinalMap = config.CardinalMap;
             UnitMap = config.UnitMap;
@@ -93,6 +95,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex AfterRegex { get; }
 
         public Regex NextRegex { get; }
+
+        public Regex NextNextRegex { get; }
+
+        public Regex LastLastRegex { get; }
 
         public Regex ThisRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             SimpleCasesRegex = ChineseDatePeriodExtractorConfiguration.SimpleCasesRegex;
             ThisRegex = ChineseDatePeriodExtractorConfiguration.ThisRegex;
             NextNextRegex = ChineseDatePeriodExtractorConfiguration.NextNextRegex;
+            LastLastRegex = ChineseDatePeriodExtractorConfiguration.LastLastRegex;
             NextRegex = ChineseDatePeriodExtractorConfiguration.NextRegex;
             LastRegex = ChineseDatePeriodExtractorConfiguration.LastRegex;
             YearToYear = ChineseDatePeriodExtractorConfiguration.YearToYear;
@@ -123,6 +124,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex ThisRegex { get; }
 
         public Regex NextNextRegex { get; }
+
+        public Regex LastLastRegex { get; }
 
         public Regex NextRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
@@ -1023,8 +1023,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // In Chinese, "下" means next, "下下周" means next next week, "下下周末" means next next weekend, need to check whether the text match "下下"
+                // "上" means last, "上上周" means last last week, "上上周末" means last last weekend, need to check whether the text match "上上"
                 ChineseDatePeriodParserConfiguration config = this.config as ChineseDatePeriodParserConfiguration;
                 bool nextNextMatch = config == null ? false : config.NextNextRegex.Match(trimmedText).Success;
+                bool lastlastMatch = config == null ? false : config.LastLastRegex.Match(trimmedText).Success;
 
                 var nextMatch = this.config.NextRegex.Match(trimmedText);
                 var lastMatch = this.config.LastRegex.Match(trimmedText);
@@ -1080,6 +1082,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         // If it is Chinese "下下周" (next next week), "下下周末" (next next weekend), then swift is 2
                         swift = 2;
+                    }
+                    else if (lastlastMatch)
+                    {
+                        // If it is Chinese "上上周" (last last week), "上上周末" (last last weekend), then swift is -2
+                        swift = -2;
                     }
                     else if (nextMatch.Success)
                     {

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -48,6 +48,12 @@ DateLastRegex: !nestedRegex
 DateNextRegex: !nestedRegex
   def: (下一个|下个|下一|下)(的)?{WeekDayRegex}
   references: [WeekDayRegex]
+DateNextNextRegex: !nestedRegex
+  def: (下下|下下[个個]){WeekDayRegex}
+  references: [WeekDayRegex]
+DateLastLastRegex: !nestedRegex
+  def: (上上|上上[个個]){WeekDayRegex}
+  references: [WeekDayRegex]
 WeekWithWeekDayRangeRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
   def: ^[.]
@@ -150,7 +156,9 @@ DatePeriodLastRegex: !simpleRegex
 DatePeriodNextRegex: !simpleRegex
   def: 下个|下一个|下|下一
 DatePeriodNextNextRegex: !simpleRegex
-  def: 下下
+  def: 下下|下下[个個]
+DatePeriodLastLastRegex: !simpleRegex
+  def: 上上|上上[个個]
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)
   references: [DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex]
@@ -183,8 +191,8 @@ PureNumYearAndMonth: !nestedRegex
   def: ({YearRegexInNumber}\s*[-\.\/]\s*{MonthNumRegex})|({MonthNumRegex}\s*\/\s*{YearRegexInNumber})
   references: [YearRegexInNumber, MonthNumRegex]
 OneWordPeriodRegex: !nestedRegex
-  def: (((?<yearrel>(明|今|去)年)\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextNextRegex}|{DatePeriodNextRegex})(?<halfTag>半)?\s*(周末|周|月|年)|周末|(今|明|去|前|后)年(\s*{HalfYearRegex})?)
-  references: [MonthRegex, DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextNextRegex, DatePeriodNextRegex, HalfYearRegex]
+  def: (((?<yearrel>(明|今|去)年)\s*)?{MonthRegex}|({DatePeriodThisRegex}|{DatePeriodLastLastRegex}|{DatePeriodLastRegex}|{DatePeriodNextNextRegex}|{DatePeriodNextRegex})(?<halfTag>半)?\s*([周週]末|[周週]|月|年)|[周週]末|(今|明|去|前|后)年(\s*{HalfYearRegex})?)
+  references: [MonthRegex, DatePeriodThisRegex, DatePeriodLastLastRegex, DatePeriodLastRegex, DatePeriodNextNextRegex, DatePeriodNextRegex, HalfYearRegex]
 LaterEarlyPeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
   def: ^[.]
@@ -567,6 +575,7 @@ WeekendTerms: !list
   types: [ string ]
   entries:
     - 周末
+    - 週末
 WeekTerms: !list
   types: [ string ]
   entries:

--- a/Specs/DateTime/Chinese/DateExtractor.json
+++ b/Specs/DateTime/Chinese/DateExtractor.json
@@ -246,6 +246,30 @@
     ]
   },
   {
+    "Input": "马拉松在下下周日举行",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "下下周日",
+        "Type": "date",
+        "Start": 4,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "任務是在上上個週三完成的",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週三",
+        "Type": "date",
+        "Start": 4,
+        "Length": 5
+      }
+    ]
+  },
+  {
     "Input": "下次的12号",
     "Results": [
       {

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -582,6 +582,54 @@
     ]
   },
   {
+    "Input": "马拉松在下下周日举行",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "下下周日",
+        "Type": "date",
+        "Value": {
+          "Timex": "2024-12-01",
+          "FutureResolution": {
+            "date": "2024-12-01"
+          },
+          "PastResolution": {
+            "date": "2024-12-01"
+          }
+        },
+        "Start": 4,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "任務是在上上個週三完成的",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週三",
+        "Type": "date",
+        "Value": {
+          "Timex": "2024-10-30",
+          "FutureResolution": {
+            "date": "2024-10-30"
+          },
+          "PastResolution": {
+            "date": "2024-10-30"
+          }
+        },
+        "Start": 4,
+        "Length": 5
+      }
+    ]
+  },
+  {
     "Input": "12号",
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"

--- a/Specs/DateTime/Chinese/DatePeriodExtractor.json
+++ b/Specs/DateTime/Chinese/DatePeriodExtractor.json
@@ -101,6 +101,30 @@
     ]
   },
   {
+    "Input": "我是上上周回来的",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上周",
+        "Type": "daterange",
+        "Start": 2,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "你上上個週末干嘛了",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週末",
+        "Type": "daterange",
+        "Start": 1,
+        "Length": 5
+      }
+    ]
+  },
+  {
     "Input": "下个月完工",
     "Results": [
       {

--- a/Specs/DateTime/Chinese/DatePeriodParser.json
+++ b/Specs/DateTime/Chinese/DatePeriodParser.json
@@ -252,6 +252,58 @@
     ]
   },
   {
+    "Input": "我是上上周回来的",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上周",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2024-W44",
+          "FutureResolution": {
+            "startDate": "2024-10-28",
+            "endDate": "2024-11-04"
+          },
+          "PastResolution": {
+            "startDate": "2024-10-28",
+            "endDate": "2024-11-04"
+          }
+        },
+        "Start": 2,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "你上上個週末干嘛了",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週末",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2024-W44-WE",
+          "FutureResolution": {
+            "startDate": "2024-11-02",
+            "endDate": "2024-11-04"
+          },
+          "PastResolution": {
+            "startDate": "2024-11-02",
+            "endDate": "2024-11-04"
+          }
+        },
+        "Start": 1,
+        "Length": 5
+      }
+    ]
+  },
+  {
     "Input": "下个月完工",
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -619,6 +619,57 @@
     ]
   },
   {
+    "Input": "我是上上周回来的",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上周",
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2024-W44",
+              "type": "daterange",
+              "start": "2024-10-28",
+              "end": "2024-11-04"
+            }
+          ]
+        },
+        "Start": 2,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "你上上個週末干嘛了",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週末",
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2024-W44-WE",
+              "type": "daterange",
+              "start": "2024-11-02",
+              "end": "2024-11-04"
+            }
+          ]
+        },
+        "Start": 1,
+        "End": 5
+      }
+    ]
+  },
+
+  {
     "Input": "后1年",
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
@@ -2365,6 +2416,54 @@
         },
         "Start": 0,
         "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "马拉松在下下周日举行",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "下下周日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2024-12-01",
+              "type": "date",
+              "value": "2024-12-01"
+            }
+          ]
+        },
+        "Start": 4,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "任務是在上上個週三完成的",
+    "Context": {
+      "ReferenceDateTime": "2024-11-15T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "上上個週三",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2024-10-30",
+              "type": "date",
+              "value": "2024-10-30"
+            }
+          ]
+        },
+        "Start": 4,
+        "End": 8
       }
     ]
   },


### PR DESCRIPTION
Support Chinese week day after/before two weeks, the week/weekend before last, below are examples.

- 下下周一（Monday after two weeks）
- 上上周日 (Sunday before two weeks) 
- 上上周末（The weekend before last）
- 上上周（The week before last）
