### PR TITLE
[ZH Email] Fix email address not be recognized when there are some Chinese characters in the sentence.

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/BaseEmail.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/BaseEmail.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Definitions
       public const string EmailRegex = @"(([-a-z0-9_\+\.]+)@([-a-z\d\.]+)\.([a-z\.]{2,6}))";
       public const string IPv4Regex = @"(?<ipv4>(\d{1,3}\.){3}\d{1,3})";
       public const string NormalSuffixRegex = @"(([0-9a-z][-]*[0-9a-z]*\.)+(?<tld>[a-z][\-a-z]{0,22}[a-z]))";
-      public const string EmailPrefix = @"(?("")("".+?(?<!\\)"")|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^\{\}\|~\w])*)(?<=[0-9a-z])))";
+      public const string EmailPrefix = @"(?("")("".+?(?<!\\)"")|(([0-9a-z]((\.(?!\.))|([-!#\$%&'\*\+/=\?\^\{\}\|~]|[a-zA-Z0-9_]))*)(?<=[0-9a-z])))";
       public static readonly string EmailSuffix = $@"(?(\[)(\[{IPv4Regex}\])|{NormalSuffixRegex})";
       public static readonly string EmailRegex2 = $@"(({EmailPrefix})@({EmailSuffix}))";
       public const string RFC5322Regex = @"\A(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|""(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*"")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])\z";

--- a/Patterns/Base-Email.yaml
+++ b/Patterns/Base-Email.yaml
@@ -6,7 +6,7 @@ IPv4Regex: !simpleRegex
 NormalSuffixRegex: !simpleRegex
   def: (([0-9a-z][-]*[0-9a-z]*\.)+(?<tld>[a-z][\-a-z]{0,22}[a-z]))
 EmailPrefix: !simpleRegex
-  def: (?("")("".+?(?<!\\)"")|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^\{\}\|~\w])*)(?<=[0-9a-z])))
+  def: (?("")("".+?(?<!\\)"")|(([0-9a-z]((\.(?!\.))|([-!#\$%&'\*\+/=\?\^\{\}\|~]|[a-zA-Z0-9_]))*)(?<=[0-9a-z])))
 EmailSuffix: !nestedRegex
   def: (?(\[)(\[{IPv4Regex}\])|{NormalSuffixRegex})
   references: [ IPv4Regex, NormalSuffixRegex ]

--- a/Specs/Sequence/English/EmailModel.json
+++ b/Specs/Sequence/English/EmailModel.json
@@ -72,6 +72,18 @@
     ]
   },
   {
+    "Input": "a邮箱地址test@test.com",
+    "Results": [
+      {
+        "Text": "test@test.com",
+        "TypeName": "email",
+        "Resolution": {
+          "value": "test@test.com"
+        }
+      }
+    ]
+  },
+  {
     "Input": "Hello, @Carol, please write to me at Dave@abc.com for more information on task #A1",
     "Results": [
       {
@@ -142,13 +154,13 @@
   },
   {
     "Input": "Both a..bc@outlook.com and .abc@hotmail.com are not valid e-mail addresses.",
-	"Comment": "By default the current system is strict. If a relaxed match is needed (to catch these), enable the Relaxed option.",
+    "Comment": "By default the current system is strict. If a relaxed match is needed (to catch these), enable the Relaxed option.",
     "NotSupportedByDesign": "javascript, python",
     "Results": []
   },
   {
     "Input": "Periods at the end of addresses can be ambiguous. Contact webmaster@contoso.com.",
-	"Comment": "By default the current system is strict. If a relaxed match is needed (to catch the period), enable the Relaxed option.",
+    "Comment": "By default the current system is strict. If a relaxed match is needed (to catch the period), enable the Relaxed option.",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {


### PR DESCRIPTION
Fix email address not be recognized when there are some Chinese characters in the sentence.
Originally, the recognizer cannot recognize the email address "test@test.com" in sentence "1邮件地址test@test.com", now fix it.

