### PR TITLE
[FR DateTimeV2] Fix the issue of 'duration' in French being parsed as a time

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string WeekWithWeekDayRangeRegex = @"^\b$";
       public const string GeneralEndingRegex = @"^\b$";
       public const string MiddlePauseRegex = @"^\b$";
-      public const string DurationConnectorRegex = @"^\b$";
+      public const string DurationConnectorRegex = @"^\s*(?<connector>\s+|et|,)\s*$";
       public const string PrefixArticleRegex = @"^[\.]";
       public const string OrRegex = @"^\b$";
       public const string YearPlusNumberRegex = @"^\b$";
@@ -748,7 +748,7 @@ namespace Microsoft.Recognizers.Definitions.French
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
-            { @"heures?$", @"\b(pour|durée\s+de|pendant)\s+(\S+\s+){1,2}heures?\b" }
+            { @"\bheures?\b", @"\b(pour|durée\s+de|pendant|dure|durera)\s+(\S+\s+){1,2}heures?.*$" }
         };
       public static readonly IList<string> MorningTermList = new List<string>
         {

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -579,8 +579,7 @@ MiddlePauseRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^\b$
 DurationConnectorRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^\b$
+  def: ^\s*(?<connector>\s+|et|,)\s*$
 PrefixArticleRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[\.]
@@ -1112,7 +1111,7 @@ AmbiguityFiltersDict: !dictionary
 AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    'heures?$': '\b(pour|durée\s+de|pendant)\s+(\S+\s+){1,2}heures?\b'
+    '\bheures?\b': '\b(pour|durée\s+de|pendant|dure|durera)\s+(\S+\s+){1,2}heures?.*$'
 # For TimeOfDay resolution
 MorningTermList: !list
   types: [ string ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2735,6 +2735,78 @@
     ]
   },
   {
+    "Input": "dure 2 heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2 heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT2H",
+              "type": "duration",
+              "value": "7200"
+            }
+          ]
+        },
+        "Start": 5,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "durera 2 heures 50 minutes",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2 heures 50 minutes",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT2H50M",
+              "type": "duration",
+              "value": "10200"
+            }
+          ]
+        },
+        "Start": 7,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "durera douze heures et vingt minutes",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "douze heures et vingt minutes",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT12H20M",
+              "type": "duration",
+              "value": "44400"
+            }
+          ]
+        },
+        "Start": 7,
+        "End": 35
+      }
+    ]
+  },
+  {
     "Input": "Je vais partir pour la ville à 3 heures",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"

--- a/Specs/DateTime/French/DurationExtractor.json
+++ b/Specs/DateTime/French/DurationExtractor.json
@@ -429,6 +429,42 @@
     ]
   },
   {
+    "Input": "dure 2 heures",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 heures",
+        "Type": "duration",
+        "Start": 5,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "durera 2 heures 50 minutes",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 heures 50 minutes",
+        "Type": "duration",
+        "Start": 7,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "durera douze heures et vingt minutes",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "douze heures et vingt minutes",
+        "Type": "duration",
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
     "Input": "Je partirai pour quelqués minutes",
     "Results": [
       {

--- a/Specs/DateTime/French/DurationParser.json
+++ b/Specs/DateTime/French/DurationParser.json
@@ -580,6 +580,69 @@
     ]
   },
   {
+    "Input": "dure 2 heures",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 heures",
+        "Type": "duration",
+        "Value": {
+          "Timex": "PT2H",
+          "FutureResolution": {
+            "duration": "7200"
+          },
+          "PastResolution": {
+            "duration": "7200"
+          }
+        },
+        "Start": 5,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "durera 2 heures 50 minutes",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 heures 50 minutes",
+        "Type": "duration",
+        "Value": {
+          "Timex": "PT2H50M",
+          "FutureResolution": {
+            "duration": "10200"
+          },
+          "PastResolution": {
+            "duration": "10200"
+          }
+        },
+        "Start": 7,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "durera douze heures et vingt minutes",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "douze heures et vingt minutes",
+        "Type": "duration",
+        "Value": {
+          "Timex": "PT12H20M",
+          "FutureResolution": {
+            "duration": "44400"
+          },
+          "PastResolution": {
+            "duration": "44400"
+          }
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
     "Input": "Je pars pour 3 heures",
     "NotSupported": "dotnet, javascript, python, java",
     "Results": [


### PR DESCRIPTION
Fix the issue of 'duration' in French being parsed as a time.
In French, "2 heures" (two hours) can be used in different contexts, mainly for telling time and indicating duration.
For example, "2 heures" in "dure 2 heures" was originally detected as time "02:00", it is incorrect, it should be a 2 hours duration.