### PR TITLE
Remove unused NuGet.CommandLine dependency to fix CVE-2024-0057

### DIFF
--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
@@ -44,7 +44,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.11.5" />
     <PackageReference Include="vswhere" Version="2.8.4" />
   </ItemGroup>
 

--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>

--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -10,9 +10,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Remove unused NuGet.CommandLine dependency to fix CVE-2024-0057.
Fixes #3150 