### PR TITLE
Fix: Support bare multiplier words in English number recognition

### DIFF
--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -31,7 +31,7 @@ TenToNineteenIntegerRegex: !simpleRegex
 TensNumberIntegerRegex: !simpleRegex
   def: (?:seventy|twenty|thirty|eighty|ninety|forty|fifty|sixty)
 SeparaIntRegex: !nestedRegex
-  def: (?:(({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s+{RoundNumberIntegerRegex})*))|(({AnIntRegex}(\s+{RoundNumberIntegerRegex})+))
+  def: (?:(({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s+{RoundNumberIntegerRegex})*))|(({AnIntRegex}(\s+{RoundNumberIntegerRegex})+))|({RoundNumberIntegerRegex}))
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex, AnIntRegex ]
 AllIntRegex: !nestedRegex
   def: (?:((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})+)\s+(and\s+)?)*{SeparaIntRegex})


### PR DESCRIPTION
## Summary
This PR fixes issue #3208 by allowing recognition of bare multiplier words like 'hundred', 'thousand', 'million', etc. without requiring an explicit coefficient prefix.

## Problem
Previously, the English number recognizer only recognized multiplier words when prefixed with a coefficient:
- ✓ 'one hundred dollars' → $100
- ✓ 'a hundred dollars' → $100
- ✗ 'hundred dollars' → Not recognized (should be $100)

This affected all NumberWithUnit models (Currency, Age, Temperature, etc.) since they depend on the Number extractor.

## Solution
Modified the `SeparaIntRegex` pattern in `Patterns/English/English-Numbers.yaml` to add support for standalone round number words by including an alternative option `({RoundNumberIntegerRegex})`.

The pattern now supports three cases:
1. Base numbers optionally followed by round numbers (e.g., 'twenty hundred')
2. Articles followed by round numbers (e.g., 'a hundred')
3. **Standalone round numbers** (e.g., 'hundred') - **NEW**

## Changes
- Modified: `Patterns/English/English-Numbers.yaml` - Updated `SeparaIntRegex` definition

## Testing
This change should be tested with:
- Recognition of bare multiplier words: 'hundred', 'thousand', 'million', 'billion', 'trillion'
- Combinations with currency: 'hundred dollars', 'thousand euros', 'million pounds'
- Combinations with other units through NumberWithUnit models
- Backward compatibility with existing patterns

Closes #3208